### PR TITLE
feat(ui): unify ModeBar across modes and hints; fix mobile overflow

### DIFF
--- a/client/interface/Interface.tsx
+++ b/client/interface/Interface.tsx
@@ -30,7 +30,7 @@ import {
   SCROLL_DEBOUNCE_DELAY,
 } from "./utils/scrolling";
 
-import type { StoryNode } from "./types";
+import type { StoryNode, MenuType } from "./types";
 import type { ModelId } from "../../shared/models";
 
 const DEFAULT_PARAMS = {
@@ -352,20 +352,30 @@ const GamepadInterface = () => {
       <div ref={containerRef} className={`container ${layout}`}>
         {/* Screen area */}
         <section className="terminal-screen" aria-label="Story Display">
-          {/* Consistent top mode bar */}
-          {activeMenu === null && (
-            <ModeBar title="LOOM" hint="START: MAP • SELECT: SETTINGS" />
-          )}
-          {activeMenu === "map" && (
-            <ModeBar title="MAP" hint="SELECT: STORIES • START: LOOM" />
-          )}
+          {/* Unified top mode bar */}
+          {(() => {
+            const map: Record<MenuType, { title: string; hint: string }> & {
+              null: { title: string; hint: string };
+            } = {
+              null: { title: "LOOM", hint: "START: MAP • SELECT: SETTINGS" },
+              map: { title: "MAP", hint: "SELECT: STORIES • START: LOOM" },
+              select: { title: "SETTINGS", hint: "START: CLOSE" },
+              start: {
+                title: "STORIES",
+                hint: "↵: SELECT • ⌫: DELETE • START: MAP",
+              },
+              edit: { title: "EDIT", hint: "SELECT: CANCEL • START: SAVE" },
+            } as const;
+            const key = activeMenu ?? null;
+            const entry = (map as any)[key];
+            return entry ? (
+              <ModeBar title={entry.title} hint={entry.hint} />
+            ) : null;
+          })()}
           {activeMenu === "select" ? (
             <>
-              <ModeBar title="SETTINGS" hint="START: CLOSE" />
               <MenuScreen
-                title=""
-                showCloseInstructions={false}
-                onClose={() => setActiveMenu(null)}
+                
               >
                 <SettingsMenu
                   params={{ ...menuParams, theme }}
@@ -392,14 +402,8 @@ const GamepadInterface = () => {
             />
           ) : activeMenu === "start" ? (
             <>
-              <ModeBar
-                title="STORIES"
-                hint="↵: SELECT • ⌫: DELETE • START: MAP"
-              />
               <MenuScreen
-                title=""
-                showCloseInstructions={false}
-                onClose={() => setActiveMenu(null)}
+                
               >
                 <TreeListMenu
                   trees={trees}
@@ -424,11 +428,7 @@ const GamepadInterface = () => {
               </MenuScreen>
             </>
           ) : activeMenu === "edit" ? (
-            <MenuScreen
-              title=""
-              onClose={() => setActiveMenu(null)}
-              showCloseInstructions={false}
-            >
+            <MenuScreen>
               <EditMenu
                 node={getCurrentPath()[currentDepth]}
                 onSave={(text) => {

--- a/client/interface/components/MenuScreen.tsx
+++ b/client/interface/components/MenuScreen.tsx
@@ -1,21 +1,5 @@
 import { MenuScreenProps } from "../types";
 
-export const MenuScreen = ({
-  title,
-  onClose,
-  children,
-  showCloseInstructions = true,
-  closeHelp,
-}: MenuScreenProps) => (
-  <div className="menu-screen">
-    {(title || showCloseInstructions) && (
-      <div className="menu-header">
-        {title && <h2>{title}</h2>}
-        {showCloseInstructions && (
-          <div className="menu-close">{closeHelp ?? "Press START to close"}</div>
-        )}
-      </div>
-    )}
-    {children}
-  </div>
+export const MenuScreen = ({ children }: MenuScreenProps) => (
+  <div className="menu-screen">{children}</div>
 );

--- a/client/interface/menus/EditMenu.tsx
+++ b/client/interface/menus/EditMenu.tsx
@@ -69,12 +69,6 @@ export const EditMenu = ({ node, onSave, onCancel }: EditMenuProps) => {
 
   return (
     <div className="menu-content" onKeyDown={handleKeyDown}>
-      <div className="menu-header">
-        <h2>Edit Node</h2>
-        <div className="menu-close">
-          Press SELECT to cancel • Press START to save
-        </div>
-      </div>
       <textarea
         ref={textareaRef}
         className="edit-textarea"

--- a/client/interface/menus/SettingsMenu.tsx
+++ b/client/interface/menus/SettingsMenu.tsx
@@ -21,7 +21,7 @@ export const SettingsMenu = ({
   const currentModel = models?.[params.model];
 
   return (
-    <menu className="menu-content">
+    <div className="menu-content">
       <MenuKnob
         label="Temperature"
         value={params.temperature}
@@ -91,6 +91,6 @@ export const SettingsMenu = ({
         </output>
       )}
       {isLoading && <output className="loading-message">Generating...</output>}
-    </menu>
+    </div>
   );
 };

--- a/client/interface/menus/TreeListMenu.tsx
+++ b/client/interface/menus/TreeListMenu.tsx
@@ -26,8 +26,6 @@ export const TreeListMenu = ({
 
   return (
     <div className="menu-content">
-      <div className="menu-instructions">↵ to select • ⌫ to delete</div>
-
       <div
         className={`menu-item ${selectedIndex === 0 ? "selected" : ""}`}
         aria-selected={selectedIndex === 0}

--- a/client/interface/types/index.ts
+++ b/client/interface/types/index.ts
@@ -8,11 +8,7 @@ export interface StoryNode {
 }
 
 export interface MenuScreenProps {
-  title: string;
-  onClose: () => void;
   children: React.ReactNode;
-  showCloseInstructions?: boolean;
-  closeHelp?: string;
 }
 
 export interface MenuKnobProps {

--- a/client/styles/terminal.css
+++ b/client/styles/terminal.css
@@ -1397,6 +1397,40 @@ progress::-moz-progress-bar {
 }
 
 /* ══════════════════════════════════════════════════════════════
+   EXTRA SMALL SCREENS: tighten spacing & prevent wrap
+   ══════════════════════════════════════════════════════════════ */
+@media (max-width: 380px) {
+    .container {
+        padding: 0.5rem;
+        gap: 0.5rem;
+    }
+
+    .terminal-screen {
+        min-width: 0; /* allow screen to fit on narrow devices */
+        padding: 0.75rem;
+    }
+
+    .controls-top {
+        padding: 0 1rem;
+        gap: 1rem;
+    }
+
+    .terminal-menu {
+        gap: 0.75rem;
+    }
+
+    .terminal-menu .btn {
+        width: 4rem;
+    }
+}
+
+@media (max-width: 330px) {
+    .terminal-menu .btn {
+        width: 3.5rem;
+    }
+}
+
+/* ══════════════════════════════════════════════════════════════
    SHARED COMPONENT STYLES (Unaffected by layout)
    ══════════════════════════════════════════════════════════════ */
 
@@ -1554,24 +1588,7 @@ progress::-moz-progress-bar {
     }
 }
 
-.menu-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.5rem 1rem;
-    border-bottom: 0.125rem solid var(--font-color);
-    margin-bottom: 1rem;
-}
-
-.menu-header h2 {
-    margin: 0;
-    font-size: 1.25rem;
-}
-
-.menu-close {
-    font-size: 0.875rem;
-    opacity: 0.7;
-}
+/* Deprecated menu header styles removed in favor of unified ModeBar */
 
 /* Compact mode bar for non-menu modes (LOOM, MAP) */
 .mode-bar {
@@ -1581,17 +1598,27 @@ progress::-moz-progress-bar {
     padding: 0.375rem 0.75rem;
     border-bottom: 0.0625rem solid var(--font-color);
     margin-bottom: 0.5rem;
+    gap: 0.5rem;
+    min-width: 0; /* allow children to shrink */
+    overflow: hidden; /* prevent horizontal scroll from hints */
 }
 
 .mode-title {
-    font-size: 0.9rem;
+    font-size: clamp(0.8rem, 2.5vw, 0.9rem);
     font-weight: 700;
     letter-spacing: 0.05em;
+    flex: 0 0 auto;
 }
 
 .mode-hint {
-    font-size: 0.8rem;
+    font-size: clamp(0.7rem, 2.2vw, 0.8rem);
     opacity: 0.75;
+    flex: 1 1 auto;
+    min-width: 0; /* enable ellipsis */
+    text-align: right;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .menu-content {


### PR DESCRIPTION
- Always render ModeBar with title+hint across LOOM/MAP/SETTINGS/STORIES/EDIT
- Make mode hints single-line with ellipsis and clamp() font sizes
- Tighten small-screen spacing to prevent wrapping/overflow
- Simplify MenuScreen to content-only wrapper and update types
- Remove deprecated menu header styles and inline menu instructions