### PR TITLE
feat(stories): reverse-chronological list and default to last active …

### DIFF
--- a/client/interface/Interface.tsx
+++ b/client/interface/Interface.tsx
@@ -115,8 +115,6 @@ const GamepadInterface = () => {
     hasAppliedDefault.current = true;
   }, [trees, orderedKeys, currentTreeKey, setCurrentTreeKey]);
 
-  // Resume last working path on load for the selected story
-
   // Calculate current highlighted node for map
   const highlightedNode = useMemo(() => {
     let node = storyTree.root;

--- a/client/interface/Interface.tsx
+++ b/client/interface/Interface.tsx
@@ -92,13 +92,7 @@ const GamepadInterface = () => {
     () => orderKeysReverseChronological(trees),
     [trees],
   );
-  const orderedTrees = useMemo(() => {
-    const obj: { [key: string]: { root: StoryNode } } = {};
-    orderedKeys.forEach((k) => {
-      obj[k] = trees[k];
-    });
-    return obj;
-  }, [orderedKeys, trees]);
+  // Use orderedKeys directly where needed; no reordered trees object required
 
   // On first load, default to the most recently active story (if any)
   const hasAppliedDefault = useRef(false);
@@ -224,7 +218,7 @@ const GamepadInterface = () => {
       }
 
       if (activeMenu === "select") {
-        handleMenuNavigation(key, orderedTrees, {
+        handleMenuNavigation(key, trees, {
           onNewTree: handleNewTree,
           onSelectTree: (key) => {
             touchStoryActive(key);
@@ -236,7 +230,7 @@ const GamepadInterface = () => {
           onThemeChange: setTheme,
         });
       } else if (activeMenu && activeMenu !== "map") {
-        handleMenuNavigation(key, orderedTrees, {
+        handleMenuNavigation(key, trees, {
           onNewTree: handleNewTree,
           onSelectTree: (key) => {
             touchStoryActive(key);
@@ -509,7 +503,7 @@ const GamepadInterface = () => {
             <>
               <MenuScreen>
                 <TreeListMenu
-                  trees={orderedTrees}
+                  trees={trees}
                   selectedIndex={selectedTreeIndex}
                   onSelect={(key) => {
                     touchStoryActive(key);
@@ -524,7 +518,7 @@ const GamepadInterface = () => {
                     // Adjust selected index if needed
                     if (selectedTreeIndex > 0) {
                       setSelectedTreeIndex((prev) =>
-                        Math.min(prev, Object.keys(orderedTrees).length - 1),
+                        Math.min(prev, Object.keys(trees).length - 1),
                       );
                     }
                   }}

--- a/client/interface/hooks/useMenuSystem.ts
+++ b/client/interface/hooks/useMenuSystem.ts
@@ -3,6 +3,10 @@ import { MenuType } from "../types";
 import type { ModelId } from "../../../shared/models";
 import { useModels } from "./useModels";
 import { scrollMenuItemElIntoView } from "../utils/scrolling";
+import {
+  orderKeysReverseChronological,
+  touchStoryActive,
+} from "../utils/storyMeta";
 
 interface MenuParams {
   temperature: number;
@@ -21,6 +25,8 @@ interface MenuCallbacks {
   currentTheme?: Theme;
   onThemeChange?: (theme: Theme) => void;
 }
+
+// Story ordering and active tracking handled by utils/storyMeta
 
 export function useMenuSystem(defaultParams: MenuParams) {
   const [activeMenu, setActiveMenu] = useState<MenuType>(null);
@@ -204,7 +210,8 @@ export function useMenuSystem(defaultParams: MenuParams) {
             break;
         }
       } else if (activeMenu === "start") {
-        const totalItems = Object.keys(trees).length + 1; // +1 for New Story
+        const orderedKeys = orderKeysReverseChronological(trees);
+        const totalItems = orderedKeys.length + 1; // +1 for New Story
 
         switch (key) {
           case "ArrowUp":
@@ -243,13 +250,14 @@ export function useMenuSystem(defaultParams: MenuParams) {
             if (selectedTreeIndex === 0) {
               callbacks.onNewTree?.();
             } else {
-              const treeKey = Object.keys(trees)[selectedTreeIndex - 1];
+              const treeKey = orderedKeys[selectedTreeIndex - 1];
+              touchStoryActive(treeKey);
               callbacks.onSelectTree?.(treeKey);
             }
             break;
           case "Backspace": // B button
-            if (selectedTreeIndex > 0 && Object.keys(trees).length > 1) {
-              const treeKey = Object.keys(trees)[selectedTreeIndex - 1];
+            if (selectedTreeIndex > 0 && orderedKeys.length > 1) {
+              const treeKey = orderedKeys[selectedTreeIndex - 1];
               callbacks.onDeleteTree?.(treeKey);
             }
             break;

--- a/client/interface/hooks/useStoryTree.ts
+++ b/client/interface/hooks/useStoryTree.ts
@@ -3,6 +3,7 @@ import type { StoryNode, InFlight, GeneratingInfo } from "../types";
 import { useStoryGeneration } from "./useStoryGeneration";
 import { useLocalStorage } from "./useLocalStorage";
 import type { ModelId } from "../../../shared/models";
+import { touchStoryUpdated } from "../utils/storyMeta";
 
 const INITIAL_STORY = {
   root: {
@@ -309,6 +310,8 @@ export function useStoryTree(params: StoryParams) {
               ...prev,
               [currentTreeKey]: updatedTree,
             }));
+            // Mark story as updated for reverse-chronological ordering
+            touchStoryUpdated(currentTreeKey);
           } catch (e) {
             console.error("Generation failed:", e);
           } finally {

--- a/client/interface/menus/TreeListMenu.tsx
+++ b/client/interface/menus/TreeListMenu.tsx
@@ -1,4 +1,5 @@
 import { TreeListProps } from "../types";
+import { sortTreeEntriesByRecency } from "../utils/storyMeta";
 
 export const TreeListMenu = ({
   trees,
@@ -7,7 +8,7 @@ export const TreeListMenu = ({
   onDelete,
   onNew,
 }: TreeListProps) => {
-  const treeEntries = Object.entries(trees);
+  const treeEntries = sortTreeEntriesByRecency(trees);
   const totalItems = treeEntries.length + 1; // +1 for "New Story" option
 
   const handleSelect = (index: number) => {

--- a/client/interface/utils/storyMeta.ts
+++ b/client/interface/utils/storyMeta.ts
@@ -113,19 +113,6 @@ export function touchStoryActive(key: string): StoryMeta {
 }
 
 /**
- * Set the last working path (array of StoryNode IDs) for a story.
- * Does not modify lastActiveAt unless you use touchActiveWithPath.
- */
-
-/**
- * Get the last working path (array of StoryNode IDs) for a story, if any.
- */
-
-/**
- * Mark story as active and record the last working path in a single call.
- */
-
-/**
  * Mark a story as "updated" (e.g., generation/edit saved).
  * Updates updatedAt. Optionally also update lastActiveAt if desired.
  */

--- a/client/interface/utils/storyMeta.ts
+++ b/client/interface/utils/storyMeta.ts
@@ -1,0 +1,233 @@
+/**
+ * Story meta utilities
+ *
+ * Purpose:
+ * - Track per-story metadata (createdAt, updatedAt, lastActiveAt, openCount)
+ * - Provide reverse-chronological ordering helpers for story lists
+ * - Provide a sensible default story to open (most recently active)
+ *
+ * Storage:
+ * - Data is persisted to localStorage under META_STORAGE_KEY
+ * - APIs degrade gracefully during SSR (no window); writes are no-ops
+ */
+
+const META_STORAGE_KEY = "story-meta-v1";
+
+export type ISODateString = string;
+
+export interface StoryMeta {
+  key: string;
+  createdAt: ISODateString; // when the story key first appeared
+  updatedAt?: ISODateString; // when content changed (generation/edit)
+  lastActiveAt?: ISODateString; // when user last focused/opened this story
+  openCount?: number; // number of times opened/focused
+}
+
+export type StoryMetaMap = Record<string, StoryMeta>;
+
+// Guarded window access for SSR
+const hasWindow = typeof window !== "undefined" && !!window.localStorage;
+
+const nowISO = (): ISODateString => new Date().toISOString();
+
+function safeLoad(): StoryMetaMap {
+  if (!hasWindow) return {};
+  try {
+    const raw = window.localStorage.getItem(META_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed as StoryMetaMap;
+    }
+  } catch {
+    // ignore
+  }
+  return {};
+}
+
+function safeSave(meta: StoryMetaMap): void {
+  if (!hasWindow) return;
+  try {
+    window.localStorage.setItem(META_STORAGE_KEY, JSON.stringify(meta));
+  } catch {
+    // ignore
+  }
+}
+
+function getOrInitMeta(
+  meta: StoryMetaMap,
+  key: string,
+  createdAt?: ISODateString,
+): StoryMeta {
+  if (!meta[key]) {
+    meta[key] = {
+      key,
+      createdAt: createdAt ?? nowISO(),
+      openCount: 0,
+    };
+  }
+  return meta[key];
+}
+
+/**
+ * Ensure meta exists for every story in the given map and remove stale meta for deleted stories.
+ * Optionally persists changes immediately.
+ */
+export function ensureMetaForTrees(
+  trees: Record<string, unknown>,
+  { persist = true }: { persist?: boolean } = {},
+): StoryMetaMap {
+  const meta = safeLoad();
+  const keys = Object.keys(trees ?? {});
+
+  // Create defaults for new keys
+  const seen = new Set<string>();
+  const createdAt = nowISO();
+  for (const key of keys) {
+    seen.add(key);
+    getOrInitMeta(meta, key, createdAt);
+  }
+
+  // Prune meta for deleted keys
+  for (const key of Object.keys(meta)) {
+    if (!seen.has(key)) {
+      delete meta[key];
+    }
+  }
+
+  if (persist) safeSave(meta);
+  return meta;
+}
+
+/**
+ * Mark a story as "active" (e.g., user opened or switched to it).
+ * Updates lastActiveAt and increments openCount.
+ */
+export function touchStoryActive(key: string): StoryMeta {
+  const meta = safeLoad();
+  const entry = getOrInitMeta(meta, key);
+  entry.lastActiveAt = nowISO();
+  entry.openCount = (entry.openCount ?? 0) + 1;
+  safeSave(meta);
+  return entry;
+}
+
+/**
+ * Set the last working path (array of StoryNode IDs) for a story.
+ * Does not modify lastActiveAt unless you use touchActiveWithPath.
+ */
+
+/**
+ * Get the last working path (array of StoryNode IDs) for a story, if any.
+ */
+
+/**
+ * Mark story as active and record the last working path in a single call.
+ */
+
+/**
+ * Mark a story as "updated" (e.g., generation/edit saved).
+ * Updates updatedAt. Optionally also update lastActiveAt if desired.
+ */
+export function touchStoryUpdated(
+  key: string,
+  { alsoActive = false }: { alsoActive?: boolean } = {},
+): StoryMeta {
+  const meta = safeLoad();
+  const entry = getOrInitMeta(meta, key);
+  const t = nowISO();
+  entry.updatedAt = t;
+  if (alsoActive) {
+    entry.lastActiveAt = t;
+    entry.openCount = (entry.openCount ?? 0) + 1;
+  }
+  safeSave(meta);
+  return entry;
+}
+
+/**
+ * Get a metadata snapshot without mutating storage.
+ */
+export function getStoryMeta(): StoryMetaMap {
+  return safeLoad();
+}
+
+/**
+ * Replace and persist metadata in storage.
+ */
+export function setStoryMeta(meta: StoryMetaMap): void {
+  safeSave(meta);
+}
+
+/**
+ * Sort story keys by recency:
+ * - Primary: lastActiveAt desc
+ * - Fallback: updatedAt desc
+ * - Fallback: createdAt desc
+ * - Stable tie-breaker: key asc
+ */
+export function orderKeysReverseChronological(
+  trees: Record<string, unknown>,
+  metaMap?: StoryMetaMap,
+): string[] {
+  const keys = Object.keys(trees ?? {});
+  if (keys.length <= 1) return keys;
+
+  const meta = metaMap ?? ensureMetaForTrees(trees, { persist: false });
+
+  const score = (key: string): [string, string, string] => {
+    const m = meta[key];
+    const a = m?.lastActiveAt ?? "";
+    const u = m?.updatedAt ?? "";
+    const c = m?.createdAt ?? "";
+    return [a, u, c];
+  };
+
+  // ISO strings sort lexicographically by chronology.
+  return keys.slice().sort((ka, kb) => {
+    const [aA, aU, aC] = score(ka);
+    const [bA, bU, bC] = score(kb);
+
+    if (aA !== bA) return bA.localeCompare(aA); // lastActiveAt desc
+    if (aU !== bU) return bU.localeCompare(aU); // updatedAt desc
+    if (aC !== bC) return bC.localeCompare(aC); // createdAt desc
+    return ka.localeCompare(kb); // stable deterministic order
+  });
+}
+
+/**
+ * Return [key, tree] entries sorted reverse-chronologically.
+ */
+export function sortTreeEntriesByRecency<T extends Record<string, unknown>>(
+  trees: T,
+  metaMap?: StoryMetaMap,
+): Array<[string, T[keyof T]]> {
+  const ordered = orderKeysReverseChronological(trees, metaMap);
+  return ordered.map((k) => [k, trees[k]] as [string, T[keyof T]]);
+}
+
+/**
+ * Choose a default story to open:
+ * - Prefer most recently active
+ * - Else most recently updated
+ * - Else most recently created
+ * - Else null when there are no stories
+ */
+export function getDefaultStoryKey(
+  trees: Record<string, unknown>,
+  metaMap?: StoryMetaMap,
+): string | null {
+  const keys = orderKeysReverseChronological(trees, metaMap);
+  return keys[0] ?? null;
+}
+
+/**
+ * Utility: mark a story as selected/opened and get an updated reverse-chronological list of keys.
+ */
+export function selectStoryAndOrder(
+  trees: Record<string, unknown>,
+  key: string,
+): string[] {
+  touchStoryActive(key);
+  return orderKeysReverseChronological(trees);
+}

--- a/client/interface/utils/storyMeta.ts
+++ b/client/interface/utils/storyMeta.ts
@@ -82,10 +82,9 @@ export function ensureMetaForTrees(
 
   // Create defaults for new keys
   const seen = new Set<string>();
-  const createdAt = nowISO();
   for (const key of keys) {
     seen.add(key);
-    getOrInitMeta(meta, key, createdAt);
+    getOrInitMeta(meta, key, nowISO());
   }
 
   // Prune meta for deleted keys


### PR DESCRIPTION
Implements reverse-chronological story ordering using local metadata (lastActiveAt, updatedAt, createdAt)
  - Default selection on load chooses the most recently active story
  - Touch lastActiveAt when selecting a story from menus; touch updatedAt on generate/edit so ordering stays fresh
  - Removes all in-story resume logic to avoid minimap/LOOM sync issues
  - Refs: #12