### PR TITLE
Enable holdable onscreen controls with combo support

### DIFF
--- a/client/interface/components/DPad.tsx
+++ b/client/interface/components/DPad.tsx
@@ -11,16 +11,16 @@ export const DPad = ({
       <GamepadButton
         label="▴"
         active={activeDirection === "up"}
-        onMouseDown={() => onControlPress("ArrowUp")}
-        onMouseUp={() => onControlRelease("ArrowUp")}
+        onPressStart={() => onControlPress("ArrowUp")}
+        onPressEnd={() => onControlRelease("ArrowUp")}
       />
     </div>
     <div className="terminal-grid-cell left-arrow">
       <GamepadButton
         label="◂"
         active={activeDirection === "left"}
-        onMouseDown={() => onControlPress("ArrowLeft")}
-        onMouseUp={() => onControlRelease("ArrowLeft")}
+        onPressStart={() => onControlPress("ArrowLeft")}
+        onPressEnd={() => onControlRelease("ArrowLeft")}
       />
     </div>
     <div className="terminal-grid-cell">
@@ -30,16 +30,16 @@ export const DPad = ({
       <GamepadButton
         label="▸"
         active={activeDirection === "right"}
-        onMouseDown={() => onControlPress("ArrowRight")}
-        onMouseUp={() => onControlRelease("ArrowRight")}
+        onPressStart={() => onControlPress("ArrowRight")}
+        onPressEnd={() => onControlRelease("ArrowRight")}
       />
     </div>
     <div className="terminal-grid-cell down-arrow">
       <GamepadButton
         label="▾"
         active={activeDirection === "down"}
-        onMouseDown={() => onControlPress("ArrowDown")}
-        onMouseUp={() => onControlRelease("ArrowDown")}
+        onPressStart={() => onControlPress("ArrowDown")}
+        onPressEnd={() => onControlRelease("ArrowDown")}
       />
     </div>
   </div>

--- a/client/interface/components/GamepadButton.tsx
+++ b/client/interface/components/GamepadButton.tsx
@@ -1,3 +1,9 @@
+import {
+  useRef,
+  type MouseEventHandler,
+  type PointerEvent as ReactPointerEvent,
+  type PointerEventHandler,
+} from "react";
 import { GamepadButtonProps } from "../types";
 
 export const GamepadButton = ({
@@ -5,16 +11,83 @@ export const GamepadButton = ({
   className = "",
   active = false,
   disabled = false,
-  onMouseDown,
-  onMouseUp,
-}: GamepadButtonProps) => (
-  <button
-    className={`btn ${active ? "btn-primary" : "btn-ghost"} ${className}`}
-    disabled={disabled}
-    onMouseDown={disabled ? undefined : onMouseDown}
-    onMouseUp={disabled ? undefined : onMouseUp}
-    aria-pressed={active}
-  >
-    {label}
-  </button>
-);
+  onPressStart,
+  onPressEnd,
+}: GamepadButtonProps) => {
+  const isPressedRef = useRef(false);
+
+  const handlePointerDown: PointerEventHandler<HTMLButtonElement> = (event) => {
+    if (disabled || isPressedRef.current) {
+      return;
+    }
+
+    isPressedRef.current = true;
+    event.preventDefault();
+
+    if (event.currentTarget.setPointerCapture) {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // Ignore pointer capture errors (e.g., unsupported environments)
+      }
+    }
+
+    void onPressStart();
+  };
+
+  const endPress = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!isPressedRef.current) {
+      return;
+    }
+
+    isPressedRef.current = false;
+
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
+    void onPressEnd();
+  };
+
+  const handlePointerUp: PointerEventHandler<HTMLButtonElement> = (event) => {
+    event.preventDefault();
+    endPress(event);
+  };
+
+  const handlePointerCancel: PointerEventHandler<HTMLButtonElement> = (event) => {
+    endPress(event);
+  };
+
+  const handlePointerLeave: PointerEventHandler<HTMLButtonElement> = (event) => {
+    if (!isPressedRef.current) {
+      return;
+    }
+
+    if (event.pointerType === "mouse" && event.buttons === 0) {
+      // Ignore hover transitions when the mouse isn't pressed
+      return;
+    }
+
+    endPress(event);
+  };
+
+  const handleContextMenu: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.preventDefault();
+  };
+
+  return (
+    <button
+      type="button"
+      className={`btn ${active ? "btn-primary" : "btn-ghost"} ${className}`}
+      disabled={disabled}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onPointerLeave={handlePointerLeave}
+      onContextMenu={handleContextMenu}
+      aria-pressed={active}
+    >
+      {label}
+    </button>
+  );
+};

--- a/client/interface/components/MenuButton.tsx
+++ b/client/interface/components/MenuButton.tsx
@@ -1,17 +1,91 @@
+import {
+  useRef,
+  type MouseEventHandler,
+  type PointerEvent as ReactPointerEvent,
+  type PointerEventHandler,
+} from "react";
 import { MenuButtonProps } from "../types";
 
 export const MenuButton = ({
   label,
   active,
-  onMouseDown,
-  onMouseUp,
-}: MenuButtonProps) => (
-  <button
-    className={`btn ${active ? "btn-primary" : "btn-ghost"}`}
-    onMouseDown={onMouseDown}
-    onMouseUp={onMouseUp}
-    aria-pressed={active}
-  >
-    {label}
-  </button>
-);
+  onPressStart,
+  onPressEnd,
+}: MenuButtonProps) => {
+  const isPressedRef = useRef(false);
+
+  const handlePointerDown: PointerEventHandler<HTMLButtonElement> = (event) => {
+    if (isPressedRef.current) {
+      return;
+    }
+
+    isPressedRef.current = true;
+    event.preventDefault();
+
+    if (event.currentTarget.setPointerCapture) {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // Ignore unsupported pointer capture
+      }
+    }
+
+    void onPressStart();
+  };
+
+  const endPress = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!isPressedRef.current) {
+      return;
+    }
+
+    isPressedRef.current = false;
+
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
+    void onPressEnd();
+  };
+
+  const handlePointerUp: PointerEventHandler<HTMLButtonElement> = (event) => {
+    event.preventDefault();
+    endPress(event);
+  };
+
+  const handlePointerCancel: PointerEventHandler<HTMLButtonElement> = (
+    event,
+  ) => {
+    endPress(event);
+  };
+
+  const handlePointerLeave: PointerEventHandler<HTMLButtonElement> = (event) => {
+    if (!isPressedRef.current) {
+      return;
+    }
+
+    if (event.pointerType === "mouse" && event.buttons === 0) {
+      return;
+    }
+
+    endPress(event);
+  };
+
+  const handleContextMenu: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.preventDefault();
+  };
+
+  return (
+    <button
+      type="button"
+      className={`btn ${active ? "btn-primary" : "btn-ghost"}`}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onPointerLeave={handlePointerLeave}
+      onContextMenu={handleContextMenu}
+      aria-pressed={active}
+    >
+      {label}
+    </button>
+  );
+};

--- a/client/interface/types/index.ts
+++ b/client/interface/types/index.ts
@@ -62,8 +62,8 @@ export interface GamepadButtonProps {
   className?: string;
   active?: boolean;
   disabled?: boolean;
-  onMouseDown: () => void;
-  onMouseUp: () => void;
+  onPressStart: () => void | Promise<void>;
+  onPressEnd: () => void | Promise<void>;
 }
 
 export interface DPadProps {
@@ -75,8 +75,8 @@ export interface DPadProps {
 export interface MenuButtonProps {
   label: string;
   active: boolean;
-  onMouseDown: () => void;
-  onMouseUp: () => void;
+  onPressStart: () => void | Promise<void>;
+  onPressEnd: () => void | Promise<void>;
 }
 
 export type InFlight = Set<string>;


### PR DESCRIPTION
## Summary
- track pressed keys inside `useKeyboardControls` to repeat held inputs and surface simultaneous key combinations to the interface logic
- switch the gamepad and menu buttons to pointer-driven press handlers so touch inputs can be held, multi-touched, and avoid accidental context menus
- extend the interface control handler to recognize a SELECT+ENTER combo, closing menus before running the Enter action so multi-button inputs can diverge from single presses

## Testing
- npm run lint *(fails: ESLint configuration file is missing in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1709948083278a204de2532d9a4d