### PR TITLE
Add models management page and dynamic store

### DIFF
--- a/client/interface/Interface.tsx
+++ b/client/interface/Interface.tsx
@@ -353,131 +353,6 @@ export const GamepadInterface = () => {
     [modelEditorFields, setSelectedModelField],
   );
 
-  const handleModelEditorAdjust = useCallback(
-    (field: ModelEditorField, delta: number) => {
-      if (field === "maxTokens") {
-        setModelForm((prev) => {
-          const next = Math.max(1, prev.maxTokens + delta * 64);
-          return {
-            ...prev,
-            maxTokens: next,
-          };
-        });
-        setModelFormError(null);
-      } else if (field === "defaultTemp") {
-        setModelForm((prev) => {
-          const next = Math.max(
-            0,
-            Math.min(2, Number((prev.defaultTemp + delta * 0.1).toFixed(1))),
-          );
-          return {
-            ...prev,
-            defaultTemp: next,
-          };
-        });
-        setModelFormError(null);
-      }
-    },
-    [],
-  );
-
-  const handleModelEditorActivate = useCallback(
-    (field: ModelEditorField) => {
-      switch (field) {
-        case "id": {
-          if (modelEditorMode === "edit") {
-            return;
-          }
-          const input = window.prompt(
-            "Model ID",
-            `${modelForm.id ?? "provider/model"}`.trim(),
-          );
-          if (input === null) return;
-          const trimmed = input.trim();
-          setModelForm((prev) => ({
-            ...prev,
-            id: (trimmed as ModelId | "") ?? ("" as ModelId | ""),
-          }));
-          setModelFormError(null);
-          break;
-        }
-        case "name": {
-          const input = window.prompt("Display Name", modelForm.name.trim());
-          if (input === null) return;
-          const trimmed = input.trim();
-          setModelForm((prev) => ({
-            ...prev,
-            name: trimmed,
-          }));
-          setModelFormError(null);
-          break;
-        }
-        case "maxTokens": {
-          const input = window.prompt("Max Tokens", `${modelForm.maxTokens}`);
-          if (input === null) return;
-          const parsed = Number.parseInt(input, 10);
-          if (!Number.isNaN(parsed) && parsed > 0) {
-            setModelForm((prev) => ({
-              ...prev,
-              maxTokens: parsed,
-            }));
-            setModelFormError(null);
-          } else {
-            setModelFormError("Max tokens must be a positive number.");
-          }
-          break;
-        }
-        case "defaultTemp": {
-          const input = window.prompt(
-            "Default Temperature",
-            modelForm.defaultTemp.toFixed(1),
-          );
-          if (input === null) return;
-          const parsed = Number.parseFloat(input);
-          if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 2) {
-            const rounded = Number(parsed.toFixed(1));
-            setModelForm((prev) => ({
-              ...prev,
-              defaultTemp: rounded,
-            }));
-            setModelFormError(null);
-          } else {
-            setModelFormError("Temperature must be between 0 and 2.");
-          }
-          break;
-        }
-        case "save": {
-          void handleSubmitModel();
-          break;
-        }
-        case "cancel": {
-          handleCancelModelEdit();
-          break;
-        }
-        case "delete": {
-          if (editingModelId) {
-            void handleDeleteModel(editingModelId);
-          }
-          break;
-        }
-        default:
-          break;
-      }
-    },
-    [
-      editingModelId,
-      handleCancelModelEdit,
-      handleDeleteModel,
-      handleSubmitModel,
-      modelEditorMode,
-      modelForm.defaultTemp,
-      modelForm.id,
-      modelForm.maxTokens,
-      modelForm.name,
-      setModelForm,
-    ],
-  );
-
   const handleDeleteModel = useCallback(
     async (modelId: ModelId) => {
       const totalModels = models ? Object.keys(models).length : 0;
@@ -617,6 +492,131 @@ export const GamepadInterface = () => {
     setMenuParams,
     showModelsMenu,
   ]);
+
+  const handleModelEditorAdjust = useCallback(
+    (field: ModelEditorField, delta: number) => {
+      if (field === "maxTokens") {
+        setModelForm((prev) => {
+          const next = Math.max(1, prev.maxTokens + delta * 64);
+          return {
+            ...prev,
+            maxTokens: next,
+          };
+        });
+        setModelFormError(null);
+      } else if (field === "defaultTemp") {
+        setModelForm((prev) => {
+          const next = Math.max(
+            0,
+            Math.min(2, Number((prev.defaultTemp + delta * 0.1).toFixed(1))),
+          );
+          return {
+            ...prev,
+            defaultTemp: next,
+          };
+        });
+        setModelFormError(null);
+      }
+    },
+    [],
+  );
+
+  const handleModelEditorActivate = useCallback(
+    (field: ModelEditorField) => {
+      switch (field) {
+        case "id": {
+          if (modelEditorMode === "edit") {
+            return;
+          }
+          const input = window.prompt(
+            "Model ID",
+            `${modelForm.id ?? "provider/model"}`.trim(),
+          );
+          if (input === null) return;
+          const trimmed = input.trim();
+          setModelForm((prev) => ({
+            ...prev,
+            id: (trimmed as ModelId | "") ?? ("" as ModelId | ""),
+          }));
+          setModelFormError(null);
+          break;
+        }
+        case "name": {
+          const input = window.prompt("Display Name", modelForm.name.trim());
+          if (input === null) return;
+          const trimmed = input.trim();
+          setModelForm((prev) => ({
+            ...prev,
+            name: trimmed,
+          }));
+          setModelFormError(null);
+          break;
+        }
+        case "maxTokens": {
+          const input = window.prompt("Max Tokens", `${modelForm.maxTokens}`);
+          if (input === null) return;
+          const parsed = Number.parseInt(input, 10);
+          if (!Number.isNaN(parsed) && parsed > 0) {
+            setModelForm((prev) => ({
+              ...prev,
+              maxTokens: parsed,
+            }));
+            setModelFormError(null);
+          } else {
+            setModelFormError("Max tokens must be a positive number.");
+          }
+          break;
+        }
+        case "defaultTemp": {
+          const input = window.prompt(
+            "Default Temperature",
+            modelForm.defaultTemp.toFixed(1),
+          );
+          if (input === null) return;
+          const parsed = Number.parseFloat(input);
+          if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 2) {
+            const rounded = Number(parsed.toFixed(1));
+            setModelForm((prev) => ({
+              ...prev,
+              defaultTemp: rounded,
+            }));
+            setModelFormError(null);
+          } else {
+            setModelFormError("Temperature must be between 0 and 2.");
+          }
+          break;
+        }
+        case "save": {
+          void handleSubmitModel();
+          break;
+        }
+        case "cancel": {
+          handleCancelModelEdit();
+          break;
+        }
+        case "delete": {
+          if (editingModelId) {
+            void handleDeleteModel(editingModelId);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [
+      editingModelId,
+      handleCancelModelEdit,
+      handleDeleteModel,
+      handleSubmitModel,
+      modelEditorMode,
+      modelForm.defaultTemp,
+      modelForm.id,
+      modelForm.maxTokens,
+      modelForm.name,
+      setModelForm,
+    ],
+  );
 
   useEffect(() => {
     const total = modelOrder.length + 2;

--- a/client/interface/Interface.tsx
+++ b/client/interface/Interface.tsx
@@ -757,6 +757,7 @@ export const GamepadInterface = () => {
           onDeleteTree: handleDeleteTree,
           currentTheme: theme,
           onThemeChange: setTheme,
+          modelOrder,
           onManageModels: () => showModelsMenu(),
         });
       } else if (activeMenu === "models") {

--- a/client/interface/components/ModelEditor.tsx
+++ b/client/interface/components/ModelEditor.tsx
@@ -1,0 +1,129 @@
+import type { ModelId } from "../../../shared/models";
+
+export interface ModelFormState {
+  id: ModelId | "";
+  name: string;
+  maxTokens: number;
+  defaultTemp: number;
+}
+
+interface ModelEditorProps {
+  formState: ModelFormState;
+  onChange: <Key extends keyof ModelFormState>(field: Key, value: ModelFormState[Key]) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  mode: "create" | "edit";
+  isSaving?: boolean;
+  error?: string | null;
+}
+
+export const ModelEditor = ({
+  formState,
+  onChange,
+  onSubmit,
+  onCancel,
+  mode,
+  isSaving = false,
+  error,
+}: ModelEditorProps) => {
+  const handleNumberChange = (
+    field: "maxTokens" | "defaultTemp",
+    value: string,
+  ) => {
+    if (field === "maxTokens") {
+      const parsed = Number.parseInt(value, 10);
+      if (!Number.isNaN(parsed)) {
+        onChange(field, parsed);
+      } else if (value === "") {
+        onChange(field, 0 as ModelFormState[typeof field]);
+      }
+    } else {
+      const parsed = Number.parseFloat(value);
+      if (!Number.isNaN(parsed)) {
+        onChange(field, parsed);
+      } else if (value === "") {
+        onChange(field, 0 as ModelFormState[typeof field]);
+      }
+    }
+  };
+
+  return (
+    <form
+      className="model-editor"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <h2 className="model-editor__title">
+        {mode === "create" ? "New Model" : "Edit Model"}
+      </h2>
+      <label className="model-editor__label" htmlFor="model-id">
+        Model ID
+      </label>
+      <input
+        id="model-id"
+        className="model-editor__input"
+        type="text"
+        value={formState.id}
+        onChange={(event) => onChange("id", event.target.value as ModelId | "")}
+        placeholder="provider/model"
+        required
+        disabled={mode === "edit"}
+      />
+
+      <label className="model-editor__label" htmlFor="model-name">
+        Display Name
+      </label>
+      <input
+        id="model-name"
+        className="model-editor__input"
+        type="text"
+        value={formState.name}
+        onChange={(event) => onChange("name", event.target.value)}
+        placeholder="Friendly name"
+        required
+      />
+
+      <label className="model-editor__label" htmlFor="model-max-tokens">
+        Max Tokens
+      </label>
+      <input
+        id="model-max-tokens"
+        className="model-editor__input"
+        type="number"
+        min={1}
+        step={1}
+        value={formState.maxTokens}
+        onChange={(event) => handleNumberChange("maxTokens", event.target.value)}
+        required
+      />
+
+      <label className="model-editor__label" htmlFor="model-default-temp">
+        Default Temperature
+      </label>
+      <input
+        id="model-default-temp"
+        className="model-editor__input"
+        type="number"
+        min={0}
+        max={2}
+        step={0.1}
+        value={formState.defaultTemp}
+        onChange={(event) => handleNumberChange("defaultTemp", event.target.value)}
+        required
+      />
+
+      {error && <output className="error-message model-editor__error">{error}</output>}
+
+      <div className="model-editor__actions">
+        <button type="submit" className="model-editor__submit" disabled={isSaving}>
+          {isSaving ? "Saving…" : "Save"}
+        </button>
+        <button type="button" className="model-editor__cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/client/interface/hooks/useMenuSystem.ts
+++ b/client/interface/hooks/useMenuSystem.ts
@@ -27,7 +27,7 @@ interface MenuCallbacks {
   onManageModels?: () => void;
   modelOrder?: ModelId[];
   onNewModel?: () => void;
-  onSelectModel?: (modelId: ModelId) => void;
+  onEditModel?: (modelId: ModelId) => void;
   onDeleteModel?: (modelId: ModelId) => void;
 }
 
@@ -307,7 +307,7 @@ export function useMenuSystem(defaultParams: MenuParams) {
             } else {
               const modelId = modelIds[selectedModelIndex - 1];
               if (modelId) {
-                callbacks.onSelectModel?.(modelId);
+                callbacks.onEditModel?.(modelId);
               }
             }
             break;
@@ -323,7 +323,12 @@ export function useMenuSystem(defaultParams: MenuParams) {
       }
 
       // Global menu controls (Enter closes non-settings menus)
-      if (key === "Enter" && activeMenu !== "select" && activeMenu !== "models") {
+      if (
+        key === "Enter" &&
+        activeMenu !== "select" &&
+        activeMenu !== "models" &&
+        activeMenu !== "model-editor"
+      ) {
         setActiveMenu(null);
       }
     },

--- a/client/interface/hooks/useMenuSystem.ts
+++ b/client/interface/hooks/useMenuSystem.ts
@@ -29,6 +29,12 @@ interface MenuCallbacks {
   onNewModel?: () => void;
   onEditModel?: (modelId: ModelId) => void;
   onDeleteModel?: (modelId: ModelId) => void;
+  onToggleModelSort?: (delta: -1 | 1) => void;
+  modelEditorFields?: string[];
+  onModelEditorEnter?: (field: string) => void;
+  onModelEditorAdjust?: (field: string, delta: number) => void;
+  onModelEditorBack?: () => void;
+  onModelEditorHighlight?: (field: string) => void;
 }
 
 // Story ordering and active tracking handled by utils/storyMeta
@@ -38,6 +44,7 @@ export function useMenuSystem(defaultParams: MenuParams) {
   const [selectedParam, setSelectedParam] = useState(0);
   const [selectedTreeIndex, setSelectedTreeIndex] = useState(0);
   const [selectedModelIndex, setSelectedModelIndex] = useState(0);
+  const [selectedModelField, setSelectedModelField] = useState(0);
   const [menuParams, setMenuParams] = useState<MenuParams>(defaultParams);
   const { models } = useModels();
   const lengthModes: LengthMode[] = ["word", "sentence", "paragraph", "page"];
@@ -268,7 +275,9 @@ export function useMenuSystem(defaultParams: MenuParams) {
         }
       } else if (activeMenu === "models") {
         const modelIds = callbacks.modelOrder ?? [];
-        const totalItems = modelIds.length + 1; // +1 for New Model
+        const hasSortRow = Boolean(callbacks.onToggleModelSort);
+        const baseOffset = hasSortRow ? 2 : 1;
+        const totalItems = modelIds.length + baseOffset;
 
         switch (key) {
           case "ArrowUp":
@@ -301,23 +310,91 @@ export function useMenuSystem(defaultParams: MenuParams) {
               return newIndex;
             });
             break;
+          case "ArrowLeft":
+            if (hasSortRow && selectedModelIndex === 0) {
+              callbacks.onToggleModelSort?.(-1);
+            }
+            break;
+          case "ArrowRight":
+            if (hasSortRow && selectedModelIndex === 0) {
+              callbacks.onToggleModelSort?.(1);
+            }
+            break;
           case "Enter":
-            if (selectedModelIndex === 0) {
+            if (hasSortRow && selectedModelIndex === 0) {
+              callbacks.onToggleModelSort?.(1);
+            } else if (selectedModelIndex === (hasSortRow ? 1 : 0)) {
               callbacks.onNewModel?.();
             } else {
-              const modelId = modelIds[selectedModelIndex - 1];
+              const modelId = modelIds[selectedModelIndex - baseOffset];
               if (modelId) {
                 callbacks.onEditModel?.(modelId);
               }
             }
             break;
           case "Backspace":
-            if (selectedModelIndex > 0) {
-              const modelId = modelIds[selectedModelIndex - 1];
+            if (selectedModelIndex >= baseOffset) {
+              const modelId = modelIds[selectedModelIndex - baseOffset];
               if (modelId) {
                 callbacks.onDeleteModel?.(modelId);
               }
             }
+            break;
+          case "`":
+            if (hasSortRow && selectedModelIndex === 0) {
+              callbacks.onToggleModelSort?.(1);
+            }
+            break;
+        }
+      } else if (activeMenu === "model-editor") {
+        const fields = callbacks.modelEditorFields ?? [];
+        const totalItems = fields.length;
+
+        if (!totalItems) {
+          return;
+        }
+
+        switch (key) {
+          case "ArrowUp":
+            setSelectedModelField((prev) => {
+              const newIndex = (prev - 1 + totalItems) % totalItems;
+              callbacks.onModelEditorHighlight?.(fields[newIndex]);
+              return newIndex;
+            });
+            break;
+          case "ArrowDown":
+            setSelectedModelField((prev) => {
+              const newIndex = (prev + 1) % totalItems;
+              callbacks.onModelEditorHighlight?.(fields[newIndex]);
+              return newIndex;
+            });
+            break;
+          case "ArrowLeft":
+            {
+              const fieldKey = fields[selectedModelField];
+              if (fieldKey) {
+                callbacks.onModelEditorAdjust?.(fieldKey, -1);
+              }
+            }
+            break;
+          case "ArrowRight":
+            {
+              const fieldKey = fields[selectedModelField];
+              if (fieldKey) {
+                callbacks.onModelEditorAdjust?.(fieldKey, 1);
+              }
+            }
+            break;
+          case "Enter":
+            {
+              const fieldKey = fields[selectedModelField];
+              if (fieldKey) {
+                callbacks.onModelEditorEnter?.(fieldKey);
+              }
+            }
+            break;
+          case "Backspace":
+            callbacks.onModelEditorBack?.();
             break;
         }
       }
@@ -337,6 +414,7 @@ export function useMenuSystem(defaultParams: MenuParams) {
       selectedParam,
       selectedTreeIndex,
       selectedModelIndex,
+      selectedModelField,
       menuParams,
       models,
       scrollMenuItemElIntoView,
@@ -352,6 +430,8 @@ export function useMenuSystem(defaultParams: MenuParams) {
     setSelectedTreeIndex,
     selectedModelIndex,
     setSelectedModelIndex,
+    selectedModelField,
+    setSelectedModelField,
     menuParams,
     setMenuParams,
     handleMenuNavigation,

--- a/client/interface/hooks/useModels.ts
+++ b/client/interface/hooks/useModels.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import type { AvailableModels, ModelId } from "../../../shared/models";
+import { useState, useEffect, useCallback } from "react";
+import type { AvailableModels, ModelConfig, ModelId } from "../../../shared/models";
 
 // Simple module-level cache so models persist across component mounts
 let cachedModels: AvailableModels | null = null;
@@ -10,6 +10,7 @@ export function useModels() {
   const [models, setModels] = useState<AvailableModels | null>(cachedModels);
   const [loading, setLoading] = useState(!cachedModels && !cachedError);
   const [error, setError] = useState<string | null>(cachedError);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     // If we've already fetched once (and cached), don't re-fetch or flip loading
@@ -26,7 +27,7 @@ export function useModels() {
         if (!response.ok) {
           throw new Error("Failed to fetch models");
         }
-        const data = await response.json();
+        const data = (await response.json()) as AvailableModels;
         cachedModels = data;
         cachedError = null;
         hasFetchedModels = true;
@@ -59,10 +60,145 @@ export function useModels() {
     return models?.[modelId] || null;
   };
 
+  const handleModelsResponse = useCallback(
+    async (response: Response) => {
+      let data: unknown = null;
+      try {
+        data = await response.json();
+      } catch (parseError) {
+        // Ignore parsing error; will throw below if not OK
+      }
+
+      if (!response.ok) {
+        const message =
+          typeof data === "object" && data && "error" in data
+            ? String((data as { error?: unknown }).error)
+            : "Failed to update models";
+        throw new Error(message);
+      }
+
+      const nextModels = (data as AvailableModels) ?? null;
+      if (nextModels) {
+        cachedModels = nextModels;
+        cachedError = null;
+        hasFetchedModels = true;
+        setModels(nextModels);
+      }
+      return nextModels;
+    },
+    [],
+  );
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/models");
+      await handleModelsResponse(response);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "An error occurred while refreshing models";
+      cachedError = message;
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [handleModelsResponse]);
+
+  const createModel = useCallback(
+    async (modelId: ModelId, config: ModelConfig) => {
+      setSaving(true);
+      setError(null);
+      try {
+        const response = await fetch("/api/models", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ id: modelId, ...config }),
+        });
+        const nextModels = await handleModelsResponse(response);
+        return nextModels;
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : "An error occurred while creating the model";
+        cachedError = message;
+        setError(message);
+        throw err;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [handleModelsResponse],
+  );
+
+  const updateExistingModel = useCallback(
+    async (modelId: ModelId, config: ModelConfig) => {
+      setSaving(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/models/${encodeURIComponent(modelId)}`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(config),
+        });
+        const nextModels = await handleModelsResponse(response);
+        return nextModels;
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : "An error occurred while updating the model";
+        cachedError = message;
+        setError(message);
+        throw err;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [handleModelsResponse],
+  );
+
+  const deleteExistingModel = useCallback(
+    async (modelId: ModelId) => {
+      setSaving(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/models/${encodeURIComponent(modelId)}`, {
+          method: "DELETE",
+        });
+        const nextModels = await handleModelsResponse(response);
+        return nextModels;
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : "An error occurred while deleting the model";
+        cachedError = message;
+        setError(message);
+        throw err;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [handleModelsResponse],
+  );
+
   return {
     models,
     loading,
     error,
+    saving,
+    refresh,
+    createModel,
+    updateModel: updateExistingModel,
+    deleteModel: deleteExistingModel,
     getModelName,
     getModelConfig,
   };

--- a/client/interface/menus/ModelsMenu.tsx
+++ b/client/interface/menus/ModelsMenu.tsx
@@ -5,11 +5,10 @@ interface ModelsMenuProps {
   modelEntries: Array<[ModelId, ModelConfig]>;
   selectedIndex: number;
   sortOrder: ModelSortOption;
-  onSortChange: (option: ModelSortOption) => void;
   onSelectIndex: (index: number) => void;
+  onToggleSort: (direction: -1 | 1) => void;
   onNew: () => void;
   onEditModel: (modelId: ModelId) => void;
-  onDeleteModel: (modelId: ModelId) => void;
   isLoading?: boolean;
   error?: string | null;
 }
@@ -23,40 +22,49 @@ export const ModelsMenu = ({
   modelEntries,
   selectedIndex,
   sortOrder,
-  onSortChange,
   onSelectIndex,
+  onToggleSort,
   onNew,
   onEditModel,
-  onDeleteModel,
   isLoading = false,
   error,
 }: ModelsMenuProps) => {
+  const handleSortActivate = () => {
+    onToggleSort(1);
+  };
+
   return (
     <div className="menu-content models-menu">
-      <div className="models-menu__toolbar">
-        <label className="models-menu__sort-label" htmlFor="models-sort">
-          Sort
-        </label>
-        <select
-          id="models-sort"
-          className="models-menu__sort-select"
-          value={sortOrder}
-          onChange={(event) =>
-            onSortChange(event.target.value as ModelSortOption)
+      <div
+        className={`menu-item models-menu__sort ${selectedIndex === 0 ? "selected" : ""}`}
+        role="button"
+        tabIndex={0}
+        onMouseEnter={() => onSelectIndex(0)}
+        onClick={handleSortActivate}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            handleSortActivate();
+          } else if (event.key === "ArrowLeft") {
+            event.preventDefault();
+            onToggleSort(-1);
+          } else if (event.key === "ArrowRight") {
+            event.preventDefault();
+            onToggleSort(1);
           }
-        >
-          {Object.entries(SORT_LABELS).map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </select>
+        }}
+      >
+        <div className="menu-item-label">Sort Models</div>
+        <div className="menu-item-preview">
+          {SORT_LABELS[sortOrder]} (◄► to change)
+        </div>
       </div>
 
       <div
-        className={`menu-item ${selectedIndex === 0 ? "selected" : ""}`}
+        className={`menu-item ${selectedIndex === 1 ? "selected" : ""}`}
+        onMouseEnter={() => onSelectIndex(1)}
         onClick={() => {
-          onSelectIndex(0);
+          onSelectIndex(1);
           onNew();
         }}
         role="button"
@@ -64,7 +72,7 @@ export const ModelsMenu = ({
         onKeyDown={(event) => {
           if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
-            onSelectIndex(0);
+            onSelectIndex(1);
             onNew();
           }
         }}
@@ -74,15 +82,17 @@ export const ModelsMenu = ({
       </div>
 
       {modelEntries.map(([modelId, config], index) => {
-        const listIndex = index + 1; // account for + New Model row
+        const listIndex = index + 2; // account for sort + new rows
         return (
           <div
             key={modelId}
             className={`menu-item models-menu__item ${
               selectedIndex === listIndex ? "selected" : ""
             }`}
+            onMouseEnter={() => onSelectIndex(listIndex)}
             onClick={() => {
               onSelectIndex(listIndex);
+              onEditModel(modelId);
             }}
             role="button"
             tabIndex={0}
@@ -97,30 +107,6 @@ export const ModelsMenu = ({
             <div className="menu-item-label">{config.name}</div>
             <div className="menu-item-preview">
               {modelId} • Max Tokens: {config.maxTokens} • Temp: {config.defaultTemp}
-            </div>
-            <div className="models-menu__actions">
-              <button
-                type="button"
-                className="models-menu__button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onSelectIndex(listIndex);
-                  onEditModel(modelId);
-                }}
-              >
-                Edit
-              </button>
-              <button
-                type="button"
-                className="models-menu__button models-menu__button--danger"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onSelectIndex(listIndex);
-                  onDeleteModel(modelId);
-                }}
-              >
-                Delete
-              </button>
             </div>
           </div>
         );

--- a/client/interface/menus/ModelsMenu.tsx
+++ b/client/interface/menus/ModelsMenu.tsx
@@ -8,7 +8,7 @@ interface ModelsMenuProps {
   onSortChange: (option: ModelSortOption) => void;
   onSelectIndex: (index: number) => void;
   onNew: () => void;
-  onSelectModel: (modelId: ModelId) => void;
+  onEditModel: (modelId: ModelId) => void;
   onDeleteModel: (modelId: ModelId) => void;
   isLoading?: boolean;
   error?: string | null;
@@ -26,14 +26,14 @@ export const ModelsMenu = ({
   onSortChange,
   onSelectIndex,
   onNew,
-  onSelectModel,
+  onEditModel,
   onDeleteModel,
   isLoading = false,
   error,
 }: ModelsMenuProps) => {
   return (
     <div className="menu-content models-menu">
-      <div className="models-menu__header">
+      <div className="models-menu__toolbar">
         <label className="models-menu__sort-label" htmlFor="models-sort">
           Sort
         </label>
@@ -78,12 +78,11 @@ export const ModelsMenu = ({
         return (
           <div
             key={modelId}
-            className={`menu-item ${
+            className={`menu-item models-menu__item ${
               selectedIndex === listIndex ? "selected" : ""
             }`}
             onClick={() => {
               onSelectIndex(listIndex);
-              onSelectModel(modelId);
             }}
             role="button"
             tabIndex={0}
@@ -91,7 +90,7 @@ export const ModelsMenu = ({
               if (event.key === "Enter" || event.key === " ") {
                 event.preventDefault();
                 onSelectIndex(listIndex);
-                onSelectModel(modelId);
+                onEditModel(modelId);
               }
             }}
           >
@@ -99,17 +98,30 @@ export const ModelsMenu = ({
             <div className="menu-item-preview">
               {modelId} • Max Tokens: {config.maxTokens} • Temp: {config.defaultTemp}
             </div>
-            <button
-              type="button"
-              className="models-menu__delete"
-              onClick={(event) => {
-                event.stopPropagation();
-                onSelectIndex(listIndex);
-                onDeleteModel(modelId);
-              }}
-            >
-              Delete
-            </button>
+            <div className="models-menu__actions">
+              <button
+                type="button"
+                className="models-menu__button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onSelectIndex(listIndex);
+                  onEditModel(modelId);
+                }}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="models-menu__button models-menu__button--danger"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onSelectIndex(listIndex);
+                  onDeleteModel(modelId);
+                }}
+              >
+                Delete
+              </button>
+            </div>
           </div>
         );
       })}

--- a/client/interface/menus/ModelsMenu.tsx
+++ b/client/interface/menus/ModelsMenu.tsx
@@ -1,0 +1,123 @@
+import type { ModelConfig, ModelId } from "../../../shared/models";
+import type { ModelSortOption } from "../types";
+
+interface ModelsMenuProps {
+  modelEntries: Array<[ModelId, ModelConfig]>;
+  selectedIndex: number;
+  sortOrder: ModelSortOption;
+  onSortChange: (option: ModelSortOption) => void;
+  onSelectIndex: (index: number) => void;
+  onNew: () => void;
+  onSelectModel: (modelId: ModelId) => void;
+  onDeleteModel: (modelId: ModelId) => void;
+  isLoading?: boolean;
+  error?: string | null;
+}
+
+const SORT_LABELS: Record<ModelSortOption, string> = {
+  "name-asc": "Name (A → Z)",
+  "name-desc": "Name (Z → A)",
+};
+
+export const ModelsMenu = ({
+  modelEntries,
+  selectedIndex,
+  sortOrder,
+  onSortChange,
+  onSelectIndex,
+  onNew,
+  onSelectModel,
+  onDeleteModel,
+  isLoading = false,
+  error,
+}: ModelsMenuProps) => {
+  return (
+    <div className="menu-content models-menu">
+      <div className="models-menu__header">
+        <label className="models-menu__sort-label" htmlFor="models-sort">
+          Sort
+        </label>
+        <select
+          id="models-sort"
+          className="models-menu__sort-select"
+          value={sortOrder}
+          onChange={(event) =>
+            onSortChange(event.target.value as ModelSortOption)
+          }
+        >
+          {Object.entries(SORT_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div
+        className={`menu-item ${selectedIndex === 0 ? "selected" : ""}`}
+        onClick={() => {
+          onSelectIndex(0);
+          onNew();
+        }}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onSelectIndex(0);
+            onNew();
+          }
+        }}
+      >
+        <div className="menu-item-label">+ New Model</div>
+        <div className="menu-item-preview">Add an OpenRouter model</div>
+      </div>
+
+      {modelEntries.map(([modelId, config], index) => {
+        const listIndex = index + 1; // account for + New Model row
+        return (
+          <div
+            key={modelId}
+            className={`menu-item ${
+              selectedIndex === listIndex ? "selected" : ""
+            }`}
+            onClick={() => {
+              onSelectIndex(listIndex);
+              onSelectModel(modelId);
+            }}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onSelectIndex(listIndex);
+                onSelectModel(modelId);
+              }
+            }}
+          >
+            <div className="menu-item-label">{config.name}</div>
+            <div className="menu-item-preview">
+              {modelId} • Max Tokens: {config.maxTokens} • Temp: {config.defaultTemp}
+            </div>
+            <button
+              type="button"
+              className="models-menu__delete"
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectIndex(listIndex);
+                onDeleteModel(modelId);
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        );
+      })}
+
+      {isLoading && (
+        <output className="loading-message">Loading models…</output>
+      )}
+      {error && <output className="error-message">{error}</output>}
+    </div>
+  );
+};

--- a/client/interface/menus/SettingsMenu.tsx
+++ b/client/interface/menus/SettingsMenu.tsx
@@ -2,7 +2,6 @@ import { SettingsMenuProps } from "../types";
 import { MenuKnob } from "../components/MenuKnob";
 import { MenuSelect } from "../components/MenuSelect";
 import { MenuToggle } from "../components/MenuToggle";
-import { useModels } from "../hooks/useModels";
 import type { ModelId } from "../../../shared/models";
 import {
   LENGTH_PRESETS,
@@ -14,12 +13,17 @@ export const SettingsMenu = ({
   onParamChange,
   selectedParam = 0,
   isLoading = false,
+  models,
+  modelsLoading = false,
+  modelsError,
+  getModelName,
+  onManageModels,
 }: SettingsMenuProps) => {
-  const { models, loading: loadingModels, error, getModelName } = useModels();
 
   // Get model options
   const modelOptions = models ? (Object.keys(models) as ModelId[]) : [];
   const modelNames = modelOptions.map(getModelName);
+  const isModelsLoading = modelsLoading && !models;
 
   const lengthModes: LengthMode[] = ["word", "sentence", "paragraph", "page"];
   const lengthModeLabels = lengthModes.map(
@@ -51,7 +55,7 @@ export const SettingsMenu = ({
         selected={selectedParam === 1}
       />
       <MenuSelect
-        label={`Model${loadingModels && !models ? " (Loading...)" : ""}`}
+        label={`Model${isModelsLoading ? " (Loading...)" : ""}`}
         value={getModelName(params.model)}
         options={modelNames}
         onChange={(value) => {
@@ -90,9 +94,26 @@ export const SettingsMenu = ({
         onChange={(value) => onParamChange("textSplitting", value)}
         selected={selectedParam === 4}
       />
-      {error && (
+      <div
+        className={`menu-item ${selectedParam === 5 ? "selected" : ""}`}
+        role="button"
+        tabIndex={0}
+        onClick={() => onManageModels?.()}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onManageModels?.();
+          }
+        }}
+      >
+        <div className="menu-item-label">Manage Models</div>
+        <div className="menu-item-preview">
+          Add, edit, or remove OpenRouter models
+        </div>
+      </div>
+      {modelsError && (
         <output className="error-message">
-          Failed to load models: {error}
+          Failed to load models: {modelsError}
         </output>
       )}
       {isLoading && <output className="loading-message">Generating...</output>}

--- a/client/interface/types/index.ts
+++ b/client/interface/types/index.ts
@@ -1,4 +1,4 @@
-import type { ModelId } from "../../../shared/models";
+import type { AvailableModels, ModelId } from "../../../shared/models";
 import type { LengthMode } from "../../../shared/lengthPresets";
 import type { Theme } from "../components/ThemeToggle";
 
@@ -49,6 +49,11 @@ export interface SettingsMenuProps {
   onParamChange: (param: string, value: number | string | boolean) => void;
   selectedParam: number;
   isLoading?: boolean;
+  models: AvailableModels | null;
+  modelsLoading?: boolean;
+  modelsError?: string | null;
+  getModelName: (modelId: ModelId) => string;
+  onManageModels?: () => void;
 }
 
 export interface TreeListProps {
@@ -81,6 +86,8 @@ export interface MenuButtonProps {
   onMouseUp: () => void;
 }
 
+export type ModelSortOption = "name-asc" | "name-desc";
+
 export type InFlight = Set<string>;
 
 export interface GeneratingInfo {
@@ -98,4 +105,4 @@ export interface ActiveControls {
   start: boolean;
 }
 
-export type MenuType = "select" | "start" | "edit" | "map" | null;
+export type MenuType = "select" | "start" | "edit" | "map" | "models" | null;

--- a/client/interface/types/index.ts
+++ b/client/interface/types/index.ts
@@ -105,4 +105,11 @@ export interface ActiveControls {
   start: boolean;
 }
 
-export type MenuType = "select" | "start" | "edit" | "map" | "models" | null;
+export type MenuType =
+  | "select"
+  | "start"
+  | "edit"
+  | "map"
+  | "models"
+  | "model-editor"
+  | null;

--- a/client/styles/terminal.css
+++ b/client/styles/terminal.css
@@ -1693,26 +1693,12 @@ progress::-moz-progress-bar {
     white-space: nowrap;
 }
 
-.models-screen {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    width: 100%;
-}
-
-@media (min-width: 768px) {
-    .models-screen {
-        flex-direction: row;
-        align-items: flex-start;
-    }
-}
-
 .models-menu {
     flex: 1;
     padding-right: 1rem;
 }
 
-.models-menu__header {
+.models-menu__toolbar {
     display: flex;
     align-items: center;
     gap: 0.75rem;
@@ -1731,18 +1717,39 @@ progress::-moz-progress-bar {
     font-family: inherit;
 }
 
-.models-menu__delete {
-    margin-top: 0.5rem;
-    align-self: flex-start;
-    background: transparent;
-    border: 0.125rem solid var(--error-color);
-    color: var(--error-color);
-    padding: 0.25rem 0.5rem;
-    cursor: pointer;
+.models-menu__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 }
 
-.models-menu__delete:hover,
-.models-menu__delete:focus {
+.models-menu__actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.models-menu__button {
+    padding: 0.25rem 0.75rem;
+    border: 0.125rem solid var(--font-color);
+    background: transparent;
+    color: var(--font-color);
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.models-menu__button:hover,
+.models-menu__button:focus {
+    background: var(--font-color);
+    color: var(--invert-font-color);
+}
+
+.models-menu__button--danger {
+    border-color: var(--error-color);
+    color: var(--error-color);
+}
+
+.models-menu__button--danger:hover,
+.models-menu__button--danger:focus {
     background: var(--error-color);
     color: var(--invert-font-color);
 }

--- a/client/styles/terminal.css
+++ b/client/styles/terminal.css
@@ -1698,118 +1698,54 @@ progress::-moz-progress-bar {
     padding-right: 1rem;
 }
 
-.models-menu__toolbar {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 0.75rem;
+.models-menu__sort {
+    cursor: pointer;
 }
 
-.models-menu__sort-label {
-    font-weight: 600;
+.models-menu__item .menu-item-preview {
+    white-space: normal;
 }
 
-.models-menu__sort-select {
-    background: transparent;
-    border: 0.125rem solid var(--font-color);
-    color: var(--font-color);
-    padding: 0.25rem 0.5rem;
-    font-family: inherit;
-}
-
-.models-menu__item {
+.model-editor-menu {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.75rem;
 }
 
-.models-menu__actions {
-    display: flex;
-    gap: 0.5rem;
+.model-editor-menu__header {
+    margin-bottom: 0.5rem;
 }
 
-.models-menu__button {
-    padding: 0.25rem 0.75rem;
-    border: 0.125rem solid var(--font-color);
-    background: transparent;
-    color: var(--font-color);
+.model-editor-menu__title {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.model-editor-menu__hint {
+    margin: 0.25rem 0 0;
+    font-size: 0.875rem;
+    opacity: 0.7;
+}
+
+.model-editor-menu__field.locked {
+    opacity: 0.6;
+}
+
+.model-editor-menu__action {
     cursor: pointer;
-    font-family: inherit;
 }
 
-.models-menu__button:hover,
-.models-menu__button:focus {
-    background: var(--font-color);
-    color: var(--invert-font-color);
-}
-
-.models-menu__button--danger {
+.model-editor-menu__action.danger {
     border-color: var(--error-color);
     color: var(--error-color);
 }
 
-.models-menu__button--danger:hover,
-.models-menu__button--danger:focus {
-    background: var(--error-color);
-    color: var(--invert-font-color);
+.model-editor-menu__action.danger.selected {
+    box-shadow: 0 0 0.25rem var(--error-color);
 }
 
-.model-editor {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    padding: 0 1rem;
-}
-
-.model-editor__title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin: 0 0 0.5rem;
-}
-
-.model-editor__label {
-    font-weight: 600;
-}
-
-.model-editor__input {
-    background: transparent;
-    border: 0.125rem solid var(--font-color);
-    color: var(--font-color);
-    padding: 0.5rem;
-    font-family: inherit;
-}
-
-.model-editor__actions {
-    display: flex;
-    gap: 0.75rem;
-    margin-top: 0.5rem;
-}
-
-.model-editor__submit,
-.model-editor__cancel {
-    padding: 0.5rem 1rem;
-    border: 0.125rem solid var(--font-color);
-    background: transparent;
-    color: var(--font-color);
-    cursor: pointer;
-}
-
-.model-editor__submit[disabled] {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
-
-.model-editor__cancel:hover,
-.model-editor__cancel:focus,
-.model-editor__submit:hover,
-.model-editor__submit:focus {
-    background: var(--font-color);
-    color: var(--invert-font-color);
-}
-
-.model-editor__error {
-    margin-top: 0.25rem;
+.model-editor-menu__knob .menu-item {
+    margin-bottom: 0;
 }
 
 /* Edit menu styles */

--- a/client/styles/terminal.css
+++ b/client/styles/terminal.css
@@ -1693,6 +1693,118 @@ progress::-moz-progress-bar {
     white-space: nowrap;
 }
 
+.models-screen {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    width: 100%;
+}
+
+@media (min-width: 768px) {
+    .models-screen {
+        flex-direction: row;
+        align-items: flex-start;
+    }
+}
+
+.models-menu {
+    flex: 1;
+    padding-right: 1rem;
+}
+
+.models-menu__header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.models-menu__sort-label {
+    font-weight: 600;
+}
+
+.models-menu__sort-select {
+    background: transparent;
+    border: 0.125rem solid var(--font-color);
+    color: var(--font-color);
+    padding: 0.25rem 0.5rem;
+    font-family: inherit;
+}
+
+.models-menu__delete {
+    margin-top: 0.5rem;
+    align-self: flex-start;
+    background: transparent;
+    border: 0.125rem solid var(--error-color);
+    color: var(--error-color);
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
+}
+
+.models-menu__delete:hover,
+.models-menu__delete:focus {
+    background: var(--error-color);
+    color: var(--invert-font-color);
+}
+
+.model-editor {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0 1rem;
+}
+
+.model-editor__title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+}
+
+.model-editor__label {
+    font-weight: 600;
+}
+
+.model-editor__input {
+    background: transparent;
+    border: 0.125rem solid var(--font-color);
+    color: var(--font-color);
+    padding: 0.5rem;
+    font-family: inherit;
+}
+
+.model-editor__actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+.model-editor__submit,
+.model-editor__cancel {
+    padding: 0.5rem 1rem;
+    border: 0.125rem solid var(--font-color);
+    background: transparent;
+    color: var(--font-color);
+    cursor: pointer;
+}
+
+.model-editor__submit[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.model-editor__cancel:hover,
+.model-editor__cancel:focus,
+.model-editor__submit:hover,
+.model-editor__submit:focus {
+    background: var(--font-color);
+    color: var(--invert-font-color);
+}
+
+.model-editor__error {
+    margin-top: 0.25rem;
+}
+
 /* Edit menu styles */
 .edit-textarea {
     width: 100%;

--- a/server/apis/http.ts
+++ b/server/apis/http.ts
@@ -4,7 +4,14 @@ import cors from "cors";
 import nocache from "nocache";
 import express, { Application } from "express";
 import { getMainProps } from "server/main_props";
-import { generateText, AVAILABLE_MODELS } from "./generation";
+import { generateText } from "./generation";
+import {
+  getModels,
+  createModel,
+  updateModel,
+  deleteModel,
+} from "../modelsStore";
+import type { ModelConfig } from "../../shared/models";
 
 export function setup_routes(app: Application) {
   // Scope API middleware to /api to avoid affecting static/SSR caching
@@ -24,6 +31,108 @@ export function setup_routes(app: Application) {
 
   // Get available models
   app.get("/api/models", (req, res) => {
-    res.json(AVAILABLE_MODELS);
+    res.json(getModels());
+  });
+
+  app.post("/api/models", (req, res) => {
+    const { id, name, maxTokens, defaultTemp } = req.body ?? {};
+    if (typeof id !== "string" || !id.trim()) {
+      return res.status(400).json({ error: "Model ID is required" });
+    }
+    if (typeof name !== "string" || !name.trim()) {
+      return res.status(400).json({ error: "Model name is required" });
+    }
+    if (
+      typeof maxTokens !== "number" ||
+      !Number.isFinite(maxTokens) ||
+      maxTokens <= 0 ||
+      !Number.isInteger(maxTokens)
+    ) {
+      return res
+        .status(400)
+        .json({ error: "maxTokens must be a positive integer" });
+    }
+    if (
+      typeof defaultTemp !== "number" ||
+      !Number.isFinite(defaultTemp) ||
+      defaultTemp < 0 ||
+      defaultTemp > 2
+    ) {
+      return res
+        .status(400)
+        .json({ error: "defaultTemp must be between 0 and 2" });
+    }
+
+    try {
+      const updated = createModel(id.trim(), {
+        name: name.trim(),
+        maxTokens,
+        defaultTemp,
+      });
+      return res.status(201).json(updated);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to create model";
+      return res.status(400).json({ error: message });
+    }
+  });
+
+  app.put("/api/models/:id", (req, res) => {
+    const targetId = req.params.id;
+    const { name, maxTokens, defaultTemp } = req.body ?? ({} as ModelConfig);
+    if (!targetId) {
+      return res.status(400).json({ error: "Model ID is required" });
+    }
+    if (typeof name !== "string" || !name.trim()) {
+      return res.status(400).json({ error: "Model name is required" });
+    }
+    if (
+      typeof maxTokens !== "number" ||
+      !Number.isFinite(maxTokens) ||
+      maxTokens <= 0 ||
+      !Number.isInteger(maxTokens)
+    ) {
+      return res
+        .status(400)
+        .json({ error: "maxTokens must be a positive integer" });
+    }
+    if (
+      typeof defaultTemp !== "number" ||
+      !Number.isFinite(defaultTemp) ||
+      defaultTemp < 0 ||
+      defaultTemp > 2
+    ) {
+      return res
+        .status(400)
+        .json({ error: "defaultTemp must be between 0 and 2" });
+    }
+
+    try {
+      const updated = updateModel(targetId, {
+        name: name.trim(),
+        maxTokens,
+        defaultTemp,
+      });
+      return res.json(updated);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to update model";
+      return res.status(400).json({ error: message });
+    }
+  });
+
+  app.delete("/api/models/:id", (req, res) => {
+    const targetId = req.params.id;
+    if (!targetId) {
+      return res.status(400).json({ error: "Model ID is required" });
+    }
+    try {
+      const updated = deleteModel(targetId);
+      return res.json(updated);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to delete model";
+      return res.status(400).json({ error: message });
+    }
   });
 }

--- a/server/data/models.json
+++ b/server/data/models.json
@@ -1,0 +1,17 @@
+{
+  "meta-llama/llama-3.1-405b": {
+    "name": "Llama 3.1 405B",
+    "maxTokens": 1024,
+    "defaultTemp": 0.7
+  },
+  "deepseek/deepseek-v3.1-base": {
+    "name": "DeepSeek V3.1",
+    "maxTokens": 1024,
+    "defaultTemp": 0.7
+  },
+  "moonshotai/kimi-k2": {
+    "name": "Kimi K2 0711",
+    "maxTokens": 1024,
+    "defaultTemp": 0.7
+  }
+}

--- a/server/modelsStore.ts
+++ b/server/modelsStore.ts
@@ -1,0 +1,121 @@
+import fs from "fs";
+import path from "path";
+import type { AvailableModels, ModelConfig, ModelId } from "../shared/models";
+
+const MODELS_FILE = path.join(process.cwd(), "server", "data", "models.json");
+
+const DEFAULT_MODELS: AvailableModels = {
+  "meta-llama/llama-3.1-405b": {
+    name: "Llama 3.1 405B",
+    maxTokens: 1024,
+    defaultTemp: 0.7,
+  },
+  "deepseek/deepseek-v3.1-base": {
+    name: "DeepSeek V3.1",
+    maxTokens: 1024,
+    defaultTemp: 0.7,
+  },
+  "moonshotai/kimi-k2": {
+    name: "Kimi K2 0711",
+    maxTokens: 1024,
+    defaultTemp: 0.7,
+  },
+};
+
+let cachedModels: AvailableModels | null = null;
+
+function ensureDirectoryExists(filePath: string) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function loadModelsFromDisk(): AvailableModels {
+  try {
+    const raw = fs.readFileSync(MODELS_FILE, "utf-8");
+    const parsed = JSON.parse(raw) as AvailableModels;
+    // Basic validation: ensure it's an object with entries
+    if (!parsed || typeof parsed !== "object") {
+      return { ...DEFAULT_MODELS };
+    }
+    return parsed;
+  } catch (error) {
+    // If file doesn't exist or is invalid, seed with defaults
+    ensureDirectoryExists(MODELS_FILE);
+    fs.writeFileSync(
+      MODELS_FILE,
+      JSON.stringify(DEFAULT_MODELS, null, 2),
+      "utf-8",
+    );
+    return { ...DEFAULT_MODELS };
+  }
+}
+
+function persistModels(models: AvailableModels) {
+  ensureDirectoryExists(MODELS_FILE);
+  fs.writeFileSync(MODELS_FILE, JSON.stringify(models, null, 2), "utf-8");
+}
+
+function getCachedModels(): AvailableModels {
+  if (!cachedModels) {
+    cachedModels = loadModelsFromDisk();
+  }
+  return cachedModels;
+}
+
+export function getModels(): AvailableModels {
+  return { ...getCachedModels() };
+}
+
+export function getModel(modelId: ModelId): ModelConfig | undefined {
+  const models = getCachedModels();
+  return models[modelId];
+}
+
+export function createModel(modelId: ModelId, config: ModelConfig): AvailableModels {
+  const models = getCachedModels();
+  if (models[modelId]) {
+    throw new Error("Model already exists");
+  }
+  const updated: AvailableModels = { ...models, [modelId]: config };
+  cachedModels = updated;
+  persistModels(updated);
+  return updated;
+}
+
+export function updateModel(
+  modelId: ModelId,
+  config: ModelConfig,
+): AvailableModels {
+  const models = getCachedModels();
+  if (!models[modelId]) {
+    throw new Error("Model not found");
+  }
+  const updated: AvailableModels = { ...models, [modelId]: config };
+  cachedModels = updated;
+  persistModels(updated);
+  return updated;
+}
+
+export function deleteModel(modelId: ModelId): AvailableModels {
+  const models = getCachedModels();
+  if (!models[modelId]) {
+    throw new Error("Model not found");
+  }
+  const updated: AvailableModels = { ...models };
+  delete updated[modelId];
+  cachedModels = updated;
+  persistModels(updated);
+  return updated;
+}
+
+export function setModels(models: AvailableModels) {
+  cachedModels = { ...models };
+  persistModels(cachedModels);
+}
+
+export function resetModelsToDefault() {
+  cachedModels = { ...DEFAULT_MODELS };
+  persistModels(cachedModels);
+}


### PR DESCRIPTION
## Summary
- add a persistent models store and expose CRUD endpoints for /api/models
- update the generation flow to resolve model config from the new store
- implement a models management screen with sorting, CRUD controls, and settings integration

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68e442192ec883278dadf3dab2515ddc