### PR TITLE
Cut Loompad over to LoomSync V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ bun.lockb
 **/credentials/*.json
 
 .env
+.data/
+test-results/
+playwright-report/

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,10 @@
     "": {
       "name": "spiel-bun",
       "dependencies": {
+        "@automerge/automerge-repo": "^2.5.5",
+        "@automerge/automerge-repo-network-broadcastchannel": "^2.5.5",
+        "@automerge/automerge-repo-network-websocket": "^2.5.5",
+        "@automerge/automerge-repo-storage-indexeddb": "^2.5.5",
         "@ax-llm/ax": "^14.0.39",
         "@tailwindcss/postcss": "^4.1.17",
         "@types/d3-flextree": "^2.1.4",
@@ -17,6 +21,7 @@
         "d3-flextree": "^2.1.2",
         "d3-hierarchy": "^3.1.2",
         "express": "^4.19.2",
+        "isomorphic-ws": "^5.0.0",
         "nocache": "^4.0.0",
         "nodemon": "^3.1.0",
         "openai": "^4.77.0",
@@ -25,10 +30,12 @@
         "srcl": "github:deepfates/srcl",
         "styled-components": "^6.1.8",
         "tailwindcss": "^4.1.17",
+        "uuid": "^14.0.0",
         "wouter": "^3.3.5",
         "yargs": "^17.7.2",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@rollup/rollup-linux-x64-gnu": "^4.52.4",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
@@ -41,6 +48,8 @@
         "typescript": "^5.2.2",
         "vite": "^5.2.8",
         "vite-plugin-pwa": "^1.0.1",
+        "vite-plugin-top-level-await": "^1.6.0",
+        "vite-plugin-wasm": "^3.6.0",
       },
     },
   },
@@ -48,6 +57,16 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@apideck/better-ajv-errors": ["@apideck/better-ajv-errors@0.3.6", "", { "dependencies": { "json-schema": "^0.4.0", "jsonpointer": "^5.0.0", "leven": "^3.1.0" }, "peerDependencies": { "ajv": ">=8" } }, "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA=="],
+
+    "@automerge/automerge": ["@automerge/automerge@3.2.6", "", {}, "sha512-9/GXXfYYWNVGpnbRrGQzTNU4fWZ3XaEMeEg0OrpK4pvlQSpkmUBoirEb/4TMK6BwMysZGV5Yeneq3wwc7RNGfg=="],
+
+    "@automerge/automerge-repo": ["@automerge/automerge-repo@2.5.5", "", { "dependencies": { "@automerge/automerge": "2.2.8 - 3", "bs58check": "^3.0.1", "cbor-x": "^1.3.0", "debug": "^4.3.4", "eventemitter3": "^5.0.1", "fast-sha256": "^1.3.0", "uuid": "^9.0.0", "xstate": "^5.9.1" } }, "sha512-A7vrMvIx5axW3smczZStONaZsksFSjKK8e0Th0u+oEV3aMsylaExpDvjRE2ZIZotJT30+l3tCUlge/n/XGK25Q=="],
+
+    "@automerge/automerge-repo-network-broadcastchannel": ["@automerge/automerge-repo-network-broadcastchannel@2.5.5", "", { "dependencies": { "@automerge/automerge-repo": "2.5.5" } }, "sha512-yYSW2lEd+aJyY6HRS2Q0PCWUmtWiGhp8oRdmL61KipRC31dZaYo+qsRVt+xw45MAC0ZBWUYHuvF6xqCPDB4Q1A=="],
+
+    "@automerge/automerge-repo-network-websocket": ["@automerge/automerge-repo-network-websocket@2.5.5", "", { "dependencies": { "@automerge/automerge-repo": "2.5.5", "cbor-x": "^1.3.0", "debug": "^4.3.4", "eventemitter3": "^5.0.1", "isomorphic-ws": "^5.0.0", "ws": "^8.7.0" } }, "sha512-pwHNXTsTTfofU3X/wtFa9L3lWfAJBI7v1+3EKgFDgEodUJo9FPDH0hcy4HUsQiDrQPADO7FP9fVOQSXVm8n5VA=="],
+
+    "@automerge/automerge-repo-storage-indexeddb": ["@automerge/automerge-repo-storage-indexeddb@2.5.5", "", { "dependencies": { "@automerge/automerge-repo": "2.5.5" } }, "sha512-pH8tw8uLqEtv1POhy2IFnpBDFpGqiR6YM3w4Rk0NkmerstUxQwrqkkeABlkvF5Al6krlu6dC47LnF8v5cHB3Fg=="],
 
     "@ax-llm/ax": ["@ax-llm/ax@14.0.39", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "dayjs": "^1.11.13" } }, "sha512-9pM32i5DLeJC9gc9oYX0m0FhRoQslXLmIKW5lSGAUQAInfl+cHwFpdYyqWoc6g6ofB3lEky1LP3M1fZlkzpLDA=="],
 
@@ -237,6 +256,18 @@
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
+    "@cbor-extract/cbor-extract-darwin-arm64": ["@cbor-extract/cbor-extract-darwin-arm64@2.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA=="],
+
+    "@cbor-extract/cbor-extract-darwin-x64": ["@cbor-extract/cbor-extract-darwin-x64@2.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q=="],
+
+    "@cbor-extract/cbor-extract-linux-arm": ["@cbor-extract/cbor-extract-linux-arm@2.2.2", "", { "os": "linux", "cpu": "arm" }, "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ=="],
+
+    "@cbor-extract/cbor-extract-linux-arm64": ["@cbor-extract/cbor-extract-linux-arm64@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg=="],
+
+    "@cbor-extract/cbor-extract-linux-x64": ["@cbor-extract/cbor-extract-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA=="],
+
+    "@cbor-extract/cbor-extract-win32-x64": ["@cbor-extract/cbor-extract-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA=="],
+
     "@emotion/is-prop-valid": ["@emotion/is-prop-valid@1.2.2", "", { "dependencies": { "@emotion/memoize": "^0.8.1" } }, "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw=="],
 
     "@emotion/memoize": ["@emotion/memoize@0.8.1", "", {}, "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="],
@@ -315,6 +346,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -322,6 +355,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@remix-run/router": ["@remix-run/router@1.23.1", "", {}, "sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ=="],
 
@@ -334,6 +369,8 @@
     "@rollup/plugin-replace": ["@rollup/plugin-replace@2.4.2", "", { "dependencies": { "@rollup/pluginutils": "^3.1.0", "magic-string": "^0.25.7" }, "peerDependencies": { "rollup": "^1.20.0 || ^2.0.0" } }, "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg=="],
 
     "@rollup/plugin-terser": ["@rollup/plugin-terser@0.4.4", "", { "dependencies": { "serialize-javascript": "^6.0.1", "smob": "^1.0.0", "terser": "^5.17.4" }, "peerDependencies": { "rollup": "^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A=="],
+
+    "@rollup/plugin-virtual": ["@rollup/plugin-virtual@3.0.2", "", { "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@3.1.0", "", { "dependencies": { "@types/estree": "0.0.39", "estree-walker": "^1.0.1", "picomatch": "^2.2.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0" } }, "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg=="],
 
@@ -382,6 +419,38 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.4", "", { "os": "win32", "cpu": "x64" }, "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
+
+    "@swc/core": ["@swc/core@1.15.30", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.30", "@swc/core-darwin-x64": "1.15.30", "@swc/core-linux-arm-gnueabihf": "1.15.30", "@swc/core-linux-arm64-gnu": "1.15.30", "@swc/core-linux-arm64-musl": "1.15.30", "@swc/core-linux-ppc64-gnu": "1.15.30", "@swc/core-linux-s390x-gnu": "1.15.30", "@swc/core-linux-x64-gnu": "1.15.30", "@swc/core-linux-x64-musl": "1.15.30", "@swc/core-win32-arm64-msvc": "1.15.30", "@swc/core-win32-ia32-msvc": "1.15.30", "@swc/core-win32-x64-msvc": "1.15.30" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ=="],
+
+    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.30", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA=="],
+
+    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.30", "", { "os": "darwin", "cpu": "x64" }, "sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg=="],
+
+    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.30", "", { "os": "linux", "cpu": "arm" }, "sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g=="],
+
+    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.30", "", { "os": "linux", "cpu": "arm64" }, "sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg=="],
+
+    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.30", "", { "os": "linux", "cpu": "arm64" }, "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA=="],
+
+    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.30", "", { "os": "linux", "cpu": "ppc64" }, "sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g=="],
+
+    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.30", "", { "os": "linux", "cpu": "s390x" }, "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g=="],
+
+    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.30", "", { "os": "linux", "cpu": "x64" }, "sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA=="],
+
+    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.30", "", { "os": "linux", "cpu": "x64" }, "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA=="],
+
+    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.30", "", { "os": "win32", "cpu": "arm64" }, "sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q=="],
+
+    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.30", "", { "os": "win32", "cpu": "ia32" }, "sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g=="],
+
+    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.30", "", { "os": "win32", "cpu": "x64" }, "sha512-4iObHPR+Q4oDY110EF5SF5eIaaVJNpMdG9C0q3Q92BsJ5y467uHz7sYQhP60WYlLFsLQ1el2YrIPUItUAQGOKg=="],
+
+    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
+
+    "@swc/types": ["@swc/types@0.1.26", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw=="],
+
+    "@swc/wasm": ["@swc/wasm@1.15.30", "", {}, "sha512-Z/27kZFJpKzmTgcOAlMrQZ3WEZOJDqk879wSY9SEuLtMVHxEZ9t4R3rGNUGj9e7ldY6GP6DCvN7Q0m7UTrhToA=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.17", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.17" } }, "sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg=="],
 
@@ -535,6 +604,8 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.8.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-i+sRXGhz4+QW8aACZ3+r1GAKMt0wlFpeA8M5rOQd0HEYw9zhDrlx9Wc8uQ0IdXakjJRthzglEwfB/yqIjO6iDg=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
@@ -546,6 +617,10 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.26.3", "", { "dependencies": { "baseline-browser-mapping": "^2.8.9", "caniuse-lite": "^1.0.30001746", "electron-to-chromium": "^1.5.227", "node-releases": "^2.0.21", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w=="],
+
+    "bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
+    "bs58check": ["bs58check@3.0.1", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^5.0.0" } }, "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -562,6 +637,10 @@
     "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001747", "", {}, "sha512-mzFa2DGIhuc5490Nd/G31xN1pnBnYMadtkyTjefPI7wzypqgCEpeWu9bJr0OnDsyKrW75zA9ZAt7pbQFmwLsQg=="],
+
+    "cbor-extract": ["cbor-extract@2.2.2", "", { "dependencies": { "node-gyp-build-optional-packages": "5.1.1" }, "optionalDependencies": { "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2", "@cbor-extract/cbor-extract-darwin-x64": "2.2.2", "@cbor-extract/cbor-extract-linux-arm": "2.2.2", "@cbor-extract/cbor-extract-linux-arm64": "2.2.2", "@cbor-extract/cbor-extract-linux-x64": "2.2.2", "@cbor-extract/cbor-extract-win32-x64": "2.2.2" }, "bin": { "download-cbor-prebuilds": "bin/download-prebuilds.js" } }, "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng=="],
+
+    "cbor-x": ["cbor-x@1.6.4", "", { "optionalDependencies": { "cbor-extract": "^2.2.2" } }, "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -707,6 +786,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -716,6 +797,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -899,6 +982,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
+
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
@@ -1005,6 +1090,8 @@
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.1.1", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw=="],
+
     "node-releases": ["node-releases@2.0.23", "", {}, "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg=="],
 
     "nodemon": ["nodemon@3.1.10", "", { "dependencies": { "chokidar": "^3.5.2", "debug": "^4", "ignore-by-default": "^1.0.1", "minimatch": "^3.1.2", "pstree.remy": "^1.1.8", "semver": "^7.5.3", "simple-update-notifier": "^2.0.0", "supports-color": "^5.5.0", "touch": "^3.1.0", "undefsafe": "^2.0.5" }, "bin": { "nodemon": "bin/nodemon.js" } }, "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw=="],
@@ -1054,6 +1141,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1289,11 +1380,17 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@5.4.20", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g=="],
 
     "vite-plugin-pwa": ["vite-plugin-pwa@1.0.3", "", { "dependencies": { "debug": "^4.3.6", "pretty-bytes": "^6.1.1", "tinyglobby": "^0.2.10", "workbox-build": "^7.3.0", "workbox-window": "^7.3.0" }, "peerDependencies": { "@vite-pwa/assets-generator": "^1.0.0", "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@vite-pwa/assets-generator"] }, "sha512-/OpqIpUldALGxcsEnv/ekQiQ5xHkQ53wcoN5ewX4jiIDNGs3W+eNcI1WYZeyOLmzoEjg09D7aX0O89YGjen1aw=="],
+
+    "vite-plugin-top-level-await": ["vite-plugin-top-level-await@1.6.0", "", { "dependencies": { "@rollup/plugin-virtual": "^3.0.2", "@swc/core": "^1.12.14", "@swc/wasm": "^1.12.14", "uuid": "10.0.0" }, "peerDependencies": { "vite": ">=2.8" } }, "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww=="],
+
+    "vite-plugin-wasm": ["vite-plugin-wasm@3.6.0", "", { "peerDependencies": { "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
@@ -1351,6 +1448,10 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xstate": ["xstate@5.30.0", "", {}, "sha512-mIzIuMjtYVkqXq9dUzYQoag7b/dF1CBS/yhliuPLfR0FwKPC18HiUivb/crcqY2gknhR8gJEhnppLg6ubQ0gGw=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
@@ -1362,6 +1463,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "@apideck/better-ajv-errors/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "@automerge/automerge-repo/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1429,6 +1532,8 @@
 
     "openai/@types/node": ["@types/node@18.19.129", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A=="],
 
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
@@ -1440,6 +1545,8 @@
     "tempy/type-fest": ["type-fest@0.16.0", "", {}, "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "vite-plugin-top-level-await/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "workbox-build/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 

--- a/client/interface/Interface.tsx
+++ b/client/interface/Interface.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef, useEffect, useState, useMemo } from "react";
 
 import { useKeyboardControls } from "./hooks/useKeyboardControls";
 import { useMenuSystem } from "./hooks/useMenuSystem";
-import { useStoryTree, INITIAL_STORY } from "./hooks/useStoryTree";
+import { useStoryTree } from "./hooks/useStoryTree";
 import { useOfflineStatus } from "./hooks/useOfflineStatus";
 import { useScrollSync } from "./hooks/useScrollSync";
 import { useModels } from "./hooks/useModels";
@@ -34,7 +34,7 @@ import ModeBar from "./components/ModeBar";
 import { splitTextToNodes } from "./utils/textSplitter";
 import { scrollElementIntoViewIfNeeded, isAtBottom } from "./utils/scrolling";
 
-import type { StoryNode, MenuType, ModelSortOption } from "./types";
+import type { MenuType, ModelSortOption } from "./types";
 import type { ModelId, ModelConfig } from "../../shared/models";
 import { DEFAULT_LENGTH_MODE } from "../../shared/lengthPresets";
 import {
@@ -49,6 +49,11 @@ import {
   downloadStoryThreadText,
   downloadStoryTreeJson,
 } from "./utils/storyExport";
+import {
+  createStoryIndexShareUrl,
+  createStoryShareUrl,
+  getStoryIndex,
+} from "./loomsync/storyRuntime";
 
 const DEFAULT_PARAMS = {
   temperature: 0.7,
@@ -140,9 +145,10 @@ export const GamepadInterface = () => {
     setCurrentTreeKey,
     getCurrentPath,
     getOptionsAtDepth,
-    setTrees,
-    setStoryTree,
     setSelectionByPath,
+    createTree,
+    deleteTree,
+    saveCurrentNodeRevision,
   } = useStoryTree(menuParams);
 
   // Compute reverse-chronologically ordered trees for menus
@@ -227,25 +233,16 @@ export const GamepadInterface = () => {
     padding: 8,
   });
 
-  const handleNewTree = useCallback(() => {
-    const newKey = `Story ${Object.keys(trees).length + 1}`;
-    setTrees((prev) => ({
-      ...prev,
-      [newKey]: INITIAL_STORY,
-    }));
+  const handleNewTree = useCallback(async () => {
+    const newKey = await createTree();
     touchStoryActive(newKey);
-    setCurrentTreeKey(newKey);
     setActiveMenu(null);
-  }, [trees, setTrees, setCurrentTreeKey, setActiveMenu]);
+  }, [createTree, setActiveMenu]);
 
   const handleDeleteTree = useCallback(
-    (key: string) => {
+    async (key: string) => {
       if (window.confirm(`Are you sure you want to delete "${key}"?`)) {
-        setTrees((prev) => {
-          const newTrees = { ...prev };
-          delete newTrees[key];
-          return newTrees;
-        });
+        await deleteTree(key);
         {
           const meta = getStoryMeta();
           if (meta[key]) {
@@ -266,8 +263,24 @@ export const GamepadInterface = () => {
         }
       }
     },
-    [currentTreeKey, trees, setTrees, setCurrentTreeKey]
+    [currentTreeKey, trees, deleteTree, setCurrentTreeKey]
   );
+
+  const copyText = useCallback(async (text: string) => {
+    await navigator.clipboard.writeText(text);
+  }, []);
+
+  const handleShareStory = useCallback(
+    async (key: string) => {
+      await copyText(createStoryShareUrl(key));
+    },
+    [copyText]
+  );
+
+  const handleShareIndex = useCallback(async () => {
+    const index = await getStoryIndex();
+    await copyText(createStoryIndexShareUrl(index.id));
+  }, [copyText]);
 
   const handleExportTree = useCallback(
     (key: string) => {
@@ -786,7 +799,7 @@ export const GamepadInterface = () => {
       if (activeMenu === "select") {
         handleMenuNavigation(key, trees, {
           onNewTree: () => {
-            handleNewTree();
+            void handleNewTree();
             setSelectedTreeColumn(0);
           },
           onSelectTree: (key) => {
@@ -796,11 +809,17 @@ export const GamepadInterface = () => {
             setSelectedTreeColumn(0);
           },
           onDeleteTree: (key) => {
-            handleDeleteTree(key);
+            void handleDeleteTree(key);
             setSelectedTreeColumn(0);
           },
           onExportTreeJson: handleExportTree,
           onExportTreeThread: handleExportThread,
+          onShareTree: (key) => {
+            void handleShareStory(key);
+          },
+          onShareIndex: () => {
+            void handleShareIndex();
+          },
           currentThemeMode: themeMode,
           currentLightTheme: lightTheme,
           currentDarkTheme: darkTheme,
@@ -842,7 +861,7 @@ export const GamepadInterface = () => {
       } else if (activeMenu && activeMenu !== "map") {
         handleMenuNavigation(key, trees, {
           onNewTree: () => {
-            handleNewTree();
+            void handleNewTree();
             setSelectedTreeColumn(0);
           },
           onSelectTree: (key) => {
@@ -852,11 +871,17 @@ export const GamepadInterface = () => {
             setSelectedTreeColumn(0);
           },
           onDeleteTree: (key) => {
-            handleDeleteTree(key);
+            void handleDeleteTree(key);
             setSelectedTreeColumn(0);
           },
           onExportTreeJson: handleExportTree,
           onExportTreeThread: handleExportThread,
+          onShareTree: (key) => {
+            void handleShareStory(key);
+          },
+          onShareIndex: () => {
+            void handleShareIndex();
+          },
         });
         // Allow START to back out from Trees to Map
         if (activeMenu === "start" && key === "Escape") {
@@ -905,6 +930,8 @@ export const GamepadInterface = () => {
       handleMenuNavigation,
       handleNewTree,
       handleDeleteTree,
+      handleShareStory,
+      handleShareIndex,
       handleDeleteModel,
       handleEditModel,
       handleStartNewModel,
@@ -1218,11 +1245,11 @@ export const GamepadInterface = () => {
                     setSelectedTreeColumn(0);
                   }}
                   onNew={() => {
-                    handleNewTree();
+                    void handleNewTree();
                     setSelectedTreeColumn(0);
                   }}
                   onDelete={(key) => {
-                    handleDeleteTree(key);
+                    void handleDeleteTree(key);
                     // Adjust selected index if needed
                     if (selectedTreeIndex > 0) {
                       setSelectedTreeIndex((prev) =>
@@ -1233,6 +1260,12 @@ export const GamepadInterface = () => {
                   }}
                   onExportJson={handleExportTree}
                   onExportThread={handleExportThread}
+                  onShareStory={(key) => {
+                    void handleShareStory(key);
+                  }}
+                  onShareIndex={() => {
+                    void handleShareIndex();
+                  }}
                   onHighlight={handleStoryHighlight}
                 />
               </MenuScreen>
@@ -1278,55 +1311,16 @@ export const GamepadInterface = () => {
             <MenuScreen>
               <EditMenu
                 node={getCurrentPath()[currentDepth]}
-                onSave={(text) => {
-                  const newTree = JSON.parse(JSON.stringify(storyTree)) as {
-                    root: StoryNode;
+                onSave={async (text) => {
+                  const splitRevision = menuParams.textSplitting
+                    ? splitTextToNodes(text)
+                    : null;
+                  const revision = splitRevision ?? {
+                    id: crypto.randomUUID(),
+                    text,
+                    continuations: [],
                   };
-                  let current = newTree.root;
-
-                  for (let i = 1; i <= currentDepth; i++) {
-                    if (!current.continuations) break;
-                    current = current.continuations[selectedOptions[i - 1]];
-                  }
-
-                  // Conditionally split the edited text based on settings
-                  if (menuParams.textSplitting) {
-                    const nodeChain = splitTextToNodes(text);
-
-                    if (nodeChain) {
-                      // Replace current node with the head of the chain
-                      current.text = nodeChain.text;
-
-                      // Preserve existing continuations by attaching them to the end of the chain
-                      const existingContinuations = current.continuations || [];
-
-                      // Walk to the end of the new chain
-                      let chainEnd = nodeChain;
-                      while (
-                        chainEnd.continuations &&
-                        chainEnd.continuations.length > 0
-                      ) {
-                        chainEnd = chainEnd.continuations[0];
-                      }
-
-                      // Attach existing continuations to the end of the chain
-                      chainEnd.continuations = existingContinuations;
-
-                      // Replace the current node's continuations with the new chain
-                      current.continuations = nodeChain.continuations;
-                      if (nodeChain.lastSelectedIndex !== undefined) {
-                        current.lastSelectedIndex = nodeChain.lastSelectedIndex;
-                      }
-                    } else {
-                      // Fallback to simple text replacement if splitting fails
-                      current.text = text;
-                    }
-                  } else {
-                    // Simple text replacement when splitting is disabled
-                    current.text = text;
-                  }
-
-                  setStoryTree(newTree);
+                  await saveCurrentNodeRevision(revision);
                   // Mark story as updated for reverse-chronological order
                   touchStoryUpdated(currentTreeKey);
                   setActiveMenu(null);

--- a/client/interface/hooks/useMenuSystem.ts
+++ b/client/interface/hooks/useMenuSystem.ts
@@ -28,6 +28,8 @@ interface MenuCallbacks {
   onDeleteTree?: (key: string) => void;
   onExportTreeJson?: (key: string) => void;
   onExportTreeThread?: (key: string) => void;
+  onShareTree?: (key: string) => void;
+  onShareIndex?: () => void;
   // Settings menu (themes)
   currentThemeMode?: ThemeMode;
   currentLightTheme?: ThemeClass;
@@ -388,7 +390,10 @@ export function useMenuSystem(defaultParams: MenuParams) {
       } else if (activeMenu === "start") {
         const orderedKeys = orderKeysReverseChronological(trees);
         const totalItems = orderedKeys.length + 1; // +1 for New Story
-        const columnTypes: Array<"story" | "json" | "thread"> = ["story"];
+        const columnTypes: Array<"story" | "share" | "json" | "thread"> = ["story"];
+        if (callbacks.onShareTree) {
+          columnTypes.push("share");
+        }
         if (callbacks.onExportTreeJson) {
           columnTypes.push("json");
         }
@@ -397,7 +402,7 @@ export function useMenuSystem(defaultParams: MenuParams) {
         }
 
         const getMaxColumnForIndex = (index: number) => {
-          if (index === 0) return 0;
+          if (index === 0) return callbacks.onShareIndex ? 1 : 0;
           return columnTypes.length - 1;
         };
 
@@ -451,7 +456,8 @@ export function useMenuSystem(defaultParams: MenuParams) {
             break;
           case "Enter": // A button
             if (selectedTreeIndex === 0) {
-              callbacks.onNewTree?.();
+              if (selectedTreeColumn === 0) callbacks.onNewTree?.();
+              else callbacks.onShareIndex?.();
             } else if (selectedTreeColumn === 0) {
               const treeKey = orderedKeys[selectedTreeIndex - 1];
               touchStoryActive(treeKey);
@@ -459,7 +465,9 @@ export function useMenuSystem(defaultParams: MenuParams) {
             } else {
               const treeKey = orderedKeys[selectedTreeIndex - 1];
               const columnType = columnTypes[selectedTreeColumn];
-              if (columnType === "json") {
+              if (columnType === "share") {
+                callbacks.onShareTree?.(treeKey);
+              } else if (columnType === "json") {
                 callbacks.onExportTreeJson?.(treeKey);
               } else if (columnType === "thread") {
                 callbacks.onExportTreeThread?.(treeKey);

--- a/client/interface/hooks/useStoryTree.ts
+++ b/client/interface/hooks/useStoryTree.ts
@@ -527,7 +527,6 @@ export function useStoryTree(params: StoryParams) {
       const appended = await appendStoryNodeRevision(
         world,
         parentId ?? null,
-        currentNode,
         revision,
       );
       const updatedTree = await refreshTreeFromWorld(currentTreeKey, world);

--- a/client/interface/hooks/useStoryTree.ts
+++ b/client/interface/hooks/useStoryTree.ts
@@ -99,10 +99,11 @@ export function useStoryTree(params: StoryParams) {
     const nextWorlds: Record<string, StoryWorld> = {};
     for (const entry of entries) {
       const world = await openStoryWorld(entry.rootId);
+      const root = await world.root();
       nextWorlds[entry.rootId] = world;
       nextTrees[entry.rootId] = await materializeStoryTree(
         world,
-        entry.meta?.rootText ?? INITIAL_STORY.root.text,
+        root.meta?.rootText ?? INITIAL_STORY.root.text,
       );
     }
     const firstKey = entries[0]?.rootId ?? Object.keys(nextTrees)[0];
@@ -118,8 +119,12 @@ export function useStoryTree(params: StoryParams) {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      await importStoryIndexFromUrl();
-      await importStoryRootFromUrl();
+      await importStoryIndexFromUrl().catch((error) => {
+        console.warn("Failed to import shared story index from URL:", error);
+      });
+      await importStoryRootFromUrl().catch((error) => {
+        console.warn("Failed to import shared story from URL:", error);
+      });
       if (!cancelled) await loadStoriesFromIndex();
     })();
     return () => {

--- a/client/interface/hooks/useStoryTree.ts
+++ b/client/interface/hooks/useStoryTree.ts
@@ -1,10 +1,28 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import type { StoryNode, InFlight, GeneratingInfo } from "../types";
 import { useStoryGeneration } from "./useStoryGeneration";
-import { useLocalStorage } from "./useLocalStorage";
 import type { ModelId } from "../../../shared/models";
 import type { LengthMode } from "../../../shared/lengthPresets";
 import { touchStoryUpdated } from "../utils/storyMeta";
+import {
+  getPreferredChildIndex,
+  setPreferredChildIndex,
+} from "../loomsync/storySessionState";
+import {
+  appendStoryNodeRevision,
+  appendStoryContinuations,
+  materializeStoryTree,
+} from "../loomsync/storyAdapter";
+import {
+  createStoryWorld,
+  getStoryIndex,
+  importStoryIndexFromUrl,
+  importStoryRootFromUrl,
+  listStoryEntries,
+  openStoryWorld,
+  removeStory,
+  type StoryWorld,
+} from "../loomsync/storyRuntime";
 
 export const INITIAL_STORY = {
   root: {
@@ -30,7 +48,8 @@ interface StoryParams {
 }
 
 export function useStoryTree(params: StoryParams) {
-  const [trees, setTrees] = useLocalStorage(DEFAULT_TREES);
+  const [trees, setTrees] = useState(DEFAULT_TREES);
+  const [worldsByKey, setWorldsByKey] = useState<Record<string, StoryWorld>>({});
   const [currentTreeKey, setCurrentTreeKey] = useState(
     () => Object.keys(trees)[0],
   );
@@ -45,6 +64,97 @@ export function useStoryTree(params: StoryParams) {
 
   const { generateContinuation, chooseContinuation, error } =
     useStoryGeneration();
+
+  const refreshTreeFromWorld = useCallback(
+    async (key: string, world: StoryWorld) => {
+      const root = await world.root();
+      const tree = await materializeStoryTree(
+        world,
+        root.meta?.rootText ?? INITIAL_STORY.root.text,
+      );
+      setTrees((prev) => ({ ...prev, [key]: tree }));
+      if (key === currentTreeKey) setStoryTree(tree);
+      return tree;
+    },
+    [currentTreeKey],
+  );
+
+  const loadStoriesFromIndex = useCallback(async () => {
+    const entries = await listStoryEntries();
+
+    if (!entries.length) {
+      const { root, world } = await createStoryWorld(
+        "Story 1",
+        INITIAL_STORY.root.text,
+      );
+      const tree = await materializeStoryTree(world, INITIAL_STORY.root.text);
+      setWorldsByKey({ [root.id]: world });
+      setTrees({ [root.id]: tree });
+      setCurrentTreeKey(root.id);
+      setStoryTree(tree);
+      return;
+    }
+
+    const nextTrees: Record<string, { root: StoryNode }> = {};
+    const nextWorlds: Record<string, StoryWorld> = {};
+    for (const entry of entries) {
+      const world = await openStoryWorld(entry.rootId);
+      nextWorlds[entry.rootId] = world;
+      nextTrees[entry.rootId] = await materializeStoryTree(
+        world,
+        entry.meta?.rootText ?? INITIAL_STORY.root.text,
+      );
+    }
+    const firstKey = entries[0]?.rootId ?? Object.keys(nextTrees)[0];
+    setWorldsByKey(nextWorlds);
+    setTrees(nextTrees);
+    setCurrentTreeKey((prev) => {
+      const nextKey = nextTrees[prev] ? prev : firstKey;
+      setStoryTree(nextTrees[nextKey] ?? nextTrees[firstKey] ?? INITIAL_STORY);
+      return nextKey;
+    });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      await importStoryIndexFromUrl();
+      await importStoryRootFromUrl();
+      if (!cancelled) await loadStoriesFromIndex();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadStoriesFromIndex]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unsubscribe: (() => void) | undefined;
+    void (async () => {
+      const index = await getStoryIndex();
+      if (cancelled) return;
+      unsubscribe = index.subscribe(() => {
+        void loadStoriesFromIndex();
+      });
+    })();
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [loadStoriesFromIndex]);
+
+  useEffect(() => {
+    const unsubs = Object.entries(worldsByKey).map(([key, world]) =>
+      world.subscribe((event) => {
+        if (event.type === "node-added" || event.type === "root-updated") {
+          void refreshTreeFromWorld(key, world);
+        }
+      }),
+    );
+    return () => {
+      for (const unsub of unsubs) unsub();
+    };
+  }, [worldsByKey, refreshTreeFromWorld]);
 
   // Helper to check if a specific node is generating
   const isGeneratingAt = useCallback(
@@ -66,16 +176,14 @@ export function useStoryTree(params: StoryParams) {
   // Helper to get the last selected index for a node
   const getLastSelectedIndex = useCallback(
     (node: StoryNode, defaultIndex: number) => {
-      if (
-        typeof node.lastSelectedIndex === "number" &&
-        node.continuations &&
-        node.lastSelectedIndex < node.continuations.length
-      ) {
-        return node.lastSelectedIndex;
-      }
-      return defaultIndex;
+      return getPreferredChildIndex(
+        currentTreeKey,
+        node.id,
+        node.continuations?.length ?? 0,
+        defaultIndex,
+      );
     },
-    [],
+    [currentTreeKey],
   );
 
   const getOptionsAtDepth = useCallback(
@@ -123,8 +231,7 @@ export function useStoryTree(params: StoryParams) {
   // Helper to update the lastSelectedIndex in the tree
   const updateLastSelectedIndex = useCallback(
     (path: StoryNode[], depth: number, index: number) => {
-      const newTree = JSON.parse(JSON.stringify(storyTree)) as typeof storyTree;
-      let current = newTree.root;
+      let current = storyTree.root;
 
       // Navigate to the node at the specified depth using the path directly
       for (let i = 1; i <= depth; i++) {
@@ -138,16 +245,9 @@ export function useStoryTree(params: StoryParams) {
         current = current.continuations![continuationIndex];
       }
 
-      // Update the lastSelectedIndex
-      current.lastSelectedIndex = index;
-
-      setStoryTree(newTree);
-      setTrees((prev) => ({
-        ...prev,
-        [currentTreeKey]: newTree,
-      }));
+      setPreferredChildIndex(currentTreeKey, current.id, index);
     },
-    [storyTree, currentTreeKey, setTrees],
+    [storyTree, currentTreeKey],
   );
 
   const generateContinuations = useCallback(
@@ -171,56 +271,12 @@ export function useStoryTree(params: StoryParams) {
     [getCurrentPath, currentDepth, params, generateContinuation],
   );
 
-  const addContinuations = useCallback(
-    (
-      baseTree: { root: StoryNode },
-      path: StoryNode[],
-      newContinuations: StoryNode[],
-      isNewChildren: boolean,
-    ) => {
-      const newTree = JSON.parse(JSON.stringify(baseTree)) as typeof baseTree;
-      let current = newTree.root;
-
-      // Navigate to the target node using path IDs to ensure we find the right node
-      for (let i = 1; i < path.length; i++) {
-        const pathNode = path[i];
-        const continuationIndex =
-          current.continuations?.findIndex((node) => node.id === pathNode.id) ??
-          -1;
-        if (continuationIndex === -1) {
-          console.error("Failed to find node in path:", {
-            pathNode,
-            currentContinuations: current.continuations,
-          });
-          return newTree;
-        }
-        current = current.continuations![continuationIndex];
-      }
-
-      // Initialize or append continuations
-      if (!current.continuations) {
-        current.continuations = newContinuations;
-      } else {
-        current.continuations = [...current.continuations, ...newContinuations];
-      }
-
-      // Set lastSelectedIndex for the current node
-      if (isNewChildren) {
-        current.lastSelectedIndex = 0;
-      } else {
-        current.lastSelectedIndex = (current.continuations?.length ?? 1) - 1;
-      }
-
-      return newTree;
-    },
-    [],
-  );
-
   const autoExpandChildren = useCallback(
     async (
+      world: StoryWorld,
       baseTree: { root: StoryNode },
       parentPath: StoryNode[],
-      generatedChildren: StoryNode[],
+      generatedChildCount: number,
       depth: number,
       params: StoryParams,
     ) => {
@@ -228,7 +284,7 @@ export function useStoryTree(params: StoryParams) {
         return baseTree;
       }
 
-      if (!generatedChildren.length) {
+      if (generatedChildCount <= 0) {
         return baseTree;
       }
 
@@ -265,7 +321,7 @@ export function useStoryTree(params: StoryParams) {
       let workingTree = baseTree;
       let currentDepth = depth;
       let currentPathIds = parentPath.map((node) => node.id);
-      let currentChildIds = generatedChildren.map((node) => node.id);
+      let currentChildIds: string[] = [];
 
       while (iterationsRemaining > 0) {
         if (
@@ -279,6 +335,12 @@ export function useStoryTree(params: StoryParams) {
 
         const parentNode = pathNodes[pathNodes.length - 1];
         if (!parentNode?.continuations?.length) break;
+
+        if (!currentChildIds.length) {
+          currentChildIds = parentNode.continuations
+            .slice(-generatedChildCount)
+            .map((node) => node.id);
+        }
 
         const candidateNodes = currentChildIds
           .map((id) =>
@@ -307,8 +369,15 @@ export function useStoryTree(params: StoryParams) {
         const selectedNode = candidateNodes[choiceIndex];
         if (!selectedNode) break;
 
-        // Remember the model's preference so navigation follows the auto-expanded path
-        parentNode.lastSelectedIndex = choiceIndex;
+        const selectedSiblingIndex =
+          parentNode.continuations?.findIndex(
+            (node) => node.id === selectedNode.id,
+          ) ?? choiceIndex;
+        setPreferredChildIndex(
+          currentTreeKey,
+          parentNode.id,
+          selectedSiblingIndex < 0 ? choiceIndex : selectedSiblingIndex,
+        );
 
         // Align the user's explicit selection state with the model's choice so
         // subsequent navigation (e.g. pressing ArrowDown) follows the
@@ -320,7 +389,8 @@ export function useStoryTree(params: StoryParams) {
             const fillCount = currentDepth - next.length + 1;
             next.push(...Array(fillCount).fill(0));
           }
-          next[currentDepth] = choiceIndex;
+          next[currentDepth] =
+            selectedSiblingIndex < 0 ? choiceIndex : selectedSiblingIndex;
           return next.slice(0, currentDepth + 1);
         });
 
@@ -389,21 +459,25 @@ export function useStoryTree(params: StoryParams) {
           });
         }
 
-        workingTree = addContinuations(
-          workingTree,
-          leafPath,
+        await appendStoryContinuations(
+          world,
+          targetNode.id === "root" ? null : targetNode.id,
           autoChildren,
-          true,
         );
+        workingTree = await refreshTreeFromWorld(currentTreeKey, world);
 
-        setStoryTree(workingTree);
-        setTrees((prev) => ({
-          ...prev,
-          [currentTreeKey]: workingTree,
-        }));
+        const refreshedTargetPath = resolvePath(
+          workingTree,
+          leafPath.map((node) => node.id),
+        );
+        const refreshedTarget =
+          refreshedTargetPath?.[refreshedTargetPath.length - 1];
+        if (!refreshedTarget?.continuations?.length) break;
 
         currentPathIds = leafPath.map((node) => node.id);
-        currentChildIds = autoChildren.map((child) => child.id);
+        currentChildIds = refreshedTarget.continuations
+          .slice(-autoChildren.length)
+          .map((child) => child.id);
         currentDepth = targetDepth;
         iterationsRemaining -= 1;
       }
@@ -413,13 +487,79 @@ export function useStoryTree(params: StoryParams) {
     [
       chooseContinuation,
       generateContinuation,
-      addContinuations,
       setSelectedOptions,
       setInFlight,
       setGeneratingInfo,
-      setStoryTree,
-      setTrees,
       currentTreeKey,
+      refreshTreeFromWorld,
+    ],
+  );
+
+    const saveCurrentNodeRevision = useCallback(
+      async (revision: StoryNode) => {
+        const world = worldsByKey[currentTreeKey];
+        if (!world) throw new Error(`Missing story world: ${currentTreeKey}`);
+
+        const currentPath = getCurrentPath();
+        const currentNode = currentPath[currentDepth];
+        if (!currentNode) return;
+
+        if (currentNode.id === "root") {
+          const root = await world.root();
+          await world.updateRootMeta({
+            ...(root.meta ?? {
+              title: currentTreeKey,
+              rootText: INITIAL_STORY.root.text,
+            }),
+            rootText: revision.text,
+          });
+          await refreshTreeFromWorld(currentTreeKey, world);
+          return;
+        }
+
+      const parentNode = currentPath[currentDepth - 1];
+      const parentId = parentNode?.id === "root" ? null : parentNode?.id;
+      const appended = await appendStoryNodeRevision(
+        world,
+        parentId ?? null,
+        currentNode,
+        revision,
+      );
+      const updatedTree = await refreshTreeFromWorld(currentTreeKey, world);
+
+        const updatedParent =
+          parentId === null
+            ? updatedTree.root
+            : (() => {
+                const findNode = (node: StoryNode): StoryNode | null => {
+                  if (node.id === parentId) return node;
+                  for (const child of node.continuations ?? []) {
+                    const found = findNode(child);
+                    if (found) return found;
+                  }
+                  return null;
+                };
+                return findNode(updatedTree.root);
+              })();
+        const selectedIndex =
+          updatedParent?.continuations?.findIndex(
+            (child) => child.id === appended.id,
+          ) ?? -1;
+        if (updatedParent && selectedIndex >= 0) {
+          setPreferredChildIndex(currentTreeKey, updatedParent.id, selectedIndex);
+          setSelectedOptions((prev) => {
+            const next = [...prev];
+            next[Math.max(0, currentDepth - 1)] = selectedIndex;
+            return next.slice(0, Math.max(1, currentDepth));
+          });
+        }
+      },
+    [
+      currentDepth,
+      currentTreeKey,
+      getCurrentPath,
+      refreshTreeFromWorld,
+      worldsByKey,
     ],
   );
 
@@ -512,23 +652,26 @@ export function useStoryTree(params: StoryParams) {
 
           try {
             const newContinuations = await generateContinuations(count);
-
-            const parentPath = currentPath.slice(0, currentDepth + 1);
-            let updatedTree = addContinuations(
-              storyTree,
-              parentPath,
+            const world = worldsByKey[currentTreeKey];
+            if (!world) throw new Error(`Missing story world: ${currentTreeKey}`);
+            await appendStoryContinuations(
+              world,
+              currentNode.id === "root" ? null : currentNode.id,
               newContinuations,
-              !hasExistingContinuations,
             );
 
+            const parentPath = currentPath.slice(0, currentDepth + 1);
+            let updatedTree = await refreshTreeFromWorld(currentTreeKey, world);
+
             if (!hasExistingContinuations && params.autoModeIterations > 0) {
-              updatedTree = await autoExpandChildren(
-                updatedTree,
-                parentPath,
-                newContinuations,
-                currentDepth,
-                params,
-              );
+                updatedTree = await autoExpandChildren(
+                  world,
+                  updatedTree,
+                  parentPath,
+                  newContinuations.length,
+                  currentDepth,
+                  params,
+                );
             }
 
             // Don't auto-jump to new nodes - let user navigate manually
@@ -563,17 +706,17 @@ export function useStoryTree(params: StoryParams) {
       }
     },
     [
-      error,
-      getCurrentPath,
-      getOptionsAtDepth,
-      currentDepth,
-      selectedOptions,
-      generateContinuations,
-      addContinuations,
-      autoExpandChildren,
-      storyTree,
-      currentTreeKey,
-      setTrees,
+        error,
+        getCurrentPath,
+        getOptionsAtDepth,
+        currentDepth,
+        selectedOptions,
+        generateContinuations,
+        autoExpandChildren,
+        storyTree,
+        currentTreeKey,
+        worldsByKey,
+        refreshTreeFromWorld,
       getLastSelectedIndex,
       updateLastSelectedIndex,
       isGeneratingAt,
@@ -599,6 +742,34 @@ export function useStoryTree(params: StoryParams) {
       setCurrentDepth(0);
       setSelectedOptions([0]);
     },
+      createTree: async () => {
+      const title = `Story ${Object.keys(trees).length + 1}`;
+      const { root, world } = await createStoryWorld(
+        title,
+        INITIAL_STORY.root.text,
+      );
+      setWorldsByKey((prev) => ({ ...prev, [root.id]: world }));
+      const tree = await materializeStoryTree(world, INITIAL_STORY.root.text);
+      setTrees((prev) => ({ ...prev, [root.id]: tree }));
+      setCurrentTreeKey(root.id);
+      setStoryTree(tree);
+      setCurrentDepth(0);
+      setSelectedOptions([0]);
+      return root.id;
+    },
+    deleteTree: async (key: string) => {
+      await removeStory(key);
+      setWorldsByKey((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+      setTrees((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    },
     // Set selection state (currentDepth and selectedOptions) from a provided path.
     // Matches path IDs against current storyTree to compute indices.
     setSelectionByPath: (path: StoryNode[]) => {
@@ -618,9 +789,8 @@ export function useStoryTree(params: StoryParams) {
       // Keep at least one element for downstream logic
       setSelectedOptions(indices.length ? indices : [0]);
     },
-    getCurrentPath,
-    getOptionsAtDepth,
-    setTrees,
-    setStoryTree,
-  };
-}
+      getCurrentPath,
+      getOptionsAtDepth,
+      saveCurrentNodeRevision,
+    };
+  }

--- a/client/interface/loomsync/storyAdapter.test.ts
+++ b/client/interface/loomsync/storyAdapter.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { createAutomergeLoomWorlds } from "../../../vendor/loomsync/packages/core/src/automerge";
+import {
+  appendStoryContinuations,
+  appendStoryNodeRevision,
+  materializeStoryTree,
+  storyTreeToSnapshot,
+} from "./storyAdapter";
+
+describe("LoomSync story adapter", () => {
+  it("converts nested Loompad trees into snapshots without shared UI selection state", async () => {
+    const worlds = createAutomergeLoomWorlds<{ text: string }, { title: string; rootText: string }>();
+    const root = await worlds.createRoot({ title: "Story", rootText: "Root" });
+    const snapshot = storyTreeToSnapshot(
+      {
+        root: {
+          id: "root",
+          text: "Root",
+          continuations: [
+            {
+              id: "a",
+              text: "A",
+              lastSelectedIndex: 1,
+              continuations: [{ id: "b", text: "B" }],
+            },
+          ],
+        },
+      },
+      root,
+    );
+
+    expect(snapshot.nodes).toHaveLength(2);
+    expect(snapshot.nodes[0]).not.toHaveProperty("lastSelectedIndex");
+  });
+
+  it("materializes and appends through an Automerge-backed world", async () => {
+    const worlds = createAutomergeLoomWorlds<{ text: string }, { title: string; rootText: string }>();
+    const root = await worlds.createRoot({ title: "Story", rootText: "Root" });
+    const world = await worlds.openRoot(root.id);
+
+    await appendStoryContinuations(world, null, [
+      { id: "ignored", text: "Once", continuations: [{ id: "ignored-2", text: " more" }] },
+    ]);
+
+    const tree = await materializeStoryTree(world, "Root");
+    expect(tree.root.continuations?.[0]?.text).toBe("Once");
+    expect(tree.root.continuations?.[0]?.continuations?.[0]?.text).toBe(" more");
+  });
+
+  it("represents edits as sibling revision branches without mutating the original node", async () => {
+    const worlds = createAutomergeLoomWorlds<{ text: string }, { title: string; rootText: string }>();
+    const root = await worlds.createRoot({ title: "Story", rootText: "Root" });
+    const world = await worlds.openRoot(root.id);
+
+    await appendStoryContinuations(world, null, [
+      {
+        id: "original",
+        text: "Original",
+        continuations: [{ id: "child", text: " child" }],
+      },
+    ]);
+
+    const [original] = await world.childrenOf(null);
+    expect(original).toBeTruthy();
+    await appendStoryNodeRevision(
+      world,
+      null,
+      {
+        id: original!.id,
+        text: "Original",
+        continuations: [{ id: "child", text: " child" }],
+      },
+      { id: "revision", text: "Revision", continuations: [] },
+    );
+
+    const tree = await materializeStoryTree(world, "Root");
+    expect(tree.root.continuations?.map((node) => node.text)).toEqual([
+      "Original",
+      "Revision",
+    ]);
+    expect(tree.root.continuations?.[0]?.continuations?.[0]?.text).toBe(" child");
+    expect(tree.root.continuations?.[1]?.continuations?.[0]?.text).toBe(" child");
+  });
+});

--- a/client/interface/loomsync/storyAdapter.test.ts
+++ b/client/interface/loomsync/storyAdapter.test.ts
@@ -47,7 +47,7 @@ describe("LoomSync story adapter", () => {
     expect(tree.root.continuations?.[0]?.continuations?.[0]?.text).toBe(" more");
   });
 
-  it("represents edits as sibling revision branches without mutating the original node", async () => {
+  it("represents edits as sibling revision branches without copying descendants", async () => {
     const worlds = createAutomergeLoomWorlds<{ text: string }, { title: string; rootText: string }>();
     const root = await worlds.createRoot({ title: "Story", rootText: "Root" });
     const world = await worlds.openRoot(root.id);
@@ -65,11 +65,6 @@ describe("LoomSync story adapter", () => {
     await appendStoryNodeRevision(
       world,
       null,
-      {
-        id: original!.id,
-        text: "Original",
-        continuations: [{ id: "child", text: " child" }],
-      },
       { id: "revision", text: "Revision", continuations: [] },
     );
 
@@ -79,6 +74,6 @@ describe("LoomSync story adapter", () => {
       "Revision",
     ]);
     expect(tree.root.continuations?.[0]?.continuations?.[0]?.text).toBe(" child");
-    expect(tree.root.continuations?.[1]?.continuations?.[0]?.text).toBe(" child");
+    expect(tree.root.continuations?.[1]?.continuations).toEqual([]);
   });
 });

--- a/client/interface/loomsync/storyAdapter.ts
+++ b/client/interface/loomsync/storyAdapter.ts
@@ -91,19 +91,9 @@ export async function appendStoryNodeChain(
 export async function appendStoryNodeRevision(
   world: LoompadStoryWorld,
   parentId: string | null,
-  currentNode: StoryNode,
   revision: StoryNode,
 ): Promise<LoomNode<TextPayload>> {
-  const revisionTree = JSON.parse(JSON.stringify(revision)) as StoryNode;
-  let chainEnd = revisionTree;
-  while (chainEnd.continuations?.length) {
-    chainEnd = chainEnd.continuations[0];
-  }
-  chainEnd.continuations = JSON.parse(
-    JSON.stringify(currentNode.continuations ?? []),
-  ) as StoryNode[];
-
-  return appendStoryNodeChain(world, parentId, revisionTree);
+  return appendStoryNodeChain(world, parentId, revision);
 }
 
 export async function appendStoryContinuations(

--- a/client/interface/loomsync/storyAdapter.ts
+++ b/client/interface/loomsync/storyAdapter.ts
@@ -1,0 +1,117 @@
+import type {
+  LoomNode,
+  LoomRoot,
+  LoomSnapshot,
+  LoomWorld,
+  LoomWorlds,
+} from "../../../vendor/loomsync/packages/core/src/types";
+import type { TextPayload } from "../../../vendor/loomsync/packages/text/src/types";
+import type { StoryNode } from "../types";
+
+export type LoompadStoryRootMeta = {
+  title: string;
+  rootText: string;
+};
+
+export type LoompadStoryWorld = LoomWorld<TextPayload, LoompadStoryRootMeta>;
+
+export async function importStoryTree(
+  worlds: LoomWorlds<TextPayload, LoompadStoryRootMeta>,
+  title: string,
+  tree: { root: StoryNode },
+): Promise<{
+  root: LoomRoot<LoompadStoryRootMeta>;
+  world: LoompadStoryWorld;
+}> {
+  const root = await worlds.createRoot({ title, rootText: tree.root.text });
+  const snapshot = storyTreeToSnapshot(tree, root);
+  const importedRoot = await worlds.importRoot(snapshot);
+  const world = await worlds.openRoot(importedRoot.id);
+  return { root: importedRoot, world };
+}
+
+export function storyTreeToSnapshot(
+  tree: { root: StoryNode },
+  root: LoomRoot<LoompadStoryRootMeta>,
+): LoomSnapshot<TextPayload, LoompadStoryRootMeta> {
+  const nodes: LoomNode<TextPayload>[] = [];
+  const visit = (node: StoryNode, parentId: string | null) => {
+    nodes.push({
+      id: node.id,
+      rootId: root.id,
+      parentId,
+      payload: { text: node.text },
+      createdAt: root.createdAt,
+    });
+    for (const child of node.continuations ?? []) visit(child, node.id);
+  };
+
+  for (const child of tree.root.continuations ?? []) visit(child, null);
+  return { root, nodes };
+}
+
+export async function materializeStoryTree(
+  world: LoompadStoryWorld,
+  rootText: string,
+): Promise<{ root: StoryNode }> {
+  const rootNode: StoryNode = {
+    id: "root",
+    text: rootText,
+    continuations: [],
+  };
+
+  const appendChildren = async (parent: StoryNode, parentId: string | null) => {
+    const children = await world.childrenOf(parentId);
+    parent.continuations = children.map((child) => ({
+      id: child.id,
+      text: child.payload.text,
+      continuations: [],
+    }));
+    for (const child of parent.continuations) {
+      await appendChildren(child, child.id);
+    }
+  };
+
+  await appendChildren(rootNode, null);
+  return { root: rootNode };
+}
+
+export async function appendStoryNodeChain(
+  world: LoompadStoryWorld,
+  parentId: string | null,
+  node: StoryNode,
+): Promise<LoomNode<TextPayload>> {
+  const appended = await world.appendAfter(parentId, { text: node.text });
+  for (const child of node.continuations ?? []) {
+    await appendStoryNodeChain(world, appended.id, child);
+  }
+  return appended;
+}
+
+export async function appendStoryNodeRevision(
+  world: LoompadStoryWorld,
+  parentId: string | null,
+  currentNode: StoryNode,
+  revision: StoryNode,
+): Promise<LoomNode<TextPayload>> {
+  const revisionTree = JSON.parse(JSON.stringify(revision)) as StoryNode;
+  let chainEnd = revisionTree;
+  while (chainEnd.continuations?.length) {
+    chainEnd = chainEnd.continuations[0];
+  }
+  chainEnd.continuations = JSON.parse(
+    JSON.stringify(currentNode.continuations ?? []),
+  ) as StoryNode[];
+
+  return appendStoryNodeChain(world, parentId, revisionTree);
+}
+
+export async function appendStoryContinuations(
+  world: LoompadStoryWorld,
+  parentId: string | null,
+  continuations: StoryNode[],
+): Promise<void> {
+  for (const continuation of continuations) {
+    await appendStoryNodeChain(world, parentId, continuation);
+  }
+}

--- a/client/interface/loomsync/storyRuntime.test.ts
+++ b/client/interface/loomsync/storyRuntime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createStoryIndexShareUrl,
+  createStoryShareUrl,
+  getStoryIndexIdFromLocation,
+  getStoryRootIdFromLocation,
+} from "./storyRuntime";
+
+describe("story runtime URLs", () => {
+  it("reads story root ids from query params and hashes through LoomSync helpers", () => {
+    expect(
+      getStoryRootIdFromLocation(new URL("https://loompad.test/?story=abc") as unknown as Location),
+    ).toBe("abc");
+    expect(
+      getStoryRootIdFromLocation(new URL("https://loompad.test/#root=def") as unknown as Location),
+    ).toBe("def");
+    expect(
+      getStoryRootIdFromLocation(new URL("https://loompad.test/#ghi") as unknown as Location),
+    ).toBe("ghi");
+  });
+
+  it("creates share urls containing the story root id", () => {
+    expect(
+      createStoryShareUrl(
+        "automerge:story",
+        new URL("https://loompad.test/path?x=1#old") as unknown as Location,
+      ),
+    ).toBe("https://loompad.test/path?x=1&story=automerge%3Astory");
+  });
+
+  it("reads and creates share urls for whole story indexes", () => {
+    expect(
+      getStoryIndexIdFromLocation(new URL("https://loompad.test/?index=idx") as unknown as Location),
+    ).toBe("idx");
+    expect(
+      createStoryIndexShareUrl(
+        "automerge:index",
+        new URL("https://loompad.test/path?story=old#root=old") as unknown as Location,
+      ),
+    ).toBe("https://loompad.test/path?index=automerge%3Aindex");
+  });
+});

--- a/client/interface/loomsync/storyRuntime.test.ts
+++ b/client/interface/loomsync/storyRuntime.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "bun:test";
+import { createMemoryLoomWorlds } from "../../../vendor/loomsync/packages/core/src/memory";
+import { createMemoryLoomIndexes } from "../../../vendor/loomsync/packages/index/src/memory";
 import {
+  addStoryRootToIndexHandle,
   createStoryIndexShareUrl,
   createStoryShareUrl,
   getStoryIndexIdFromLocation,
   getStoryRootIdFromLocation,
+  importStoryRootFromLocation,
 } from "./storyRuntime";
 
 describe("story runtime URLs", () => {
@@ -38,5 +42,46 @@ describe("story runtime URLs", () => {
         new URL("https://loompad.test/path?story=old#root=old") as unknown as Location,
       ),
     ).toBe("https://loompad.test/path?index=automerge%3Aindex");
+  });
+
+  it("refreshes existing index entry metadata when importing a shared root", async () => {
+    const worlds = createMemoryLoomWorlds<{ text: string }, { title: string; rootText: string }>({
+      createId: () => "story",
+    });
+    const root = await worlds.createRoot({ title: "Story", rootText: "Old" });
+    const world = await worlds.openRoot(root.id);
+    await world.updateRootMeta({ title: "Story", rootText: "Edited" });
+
+    const indexes = createMemoryLoomIndexes<{ title: string; rootText: string }, { app: "loompad" }>({
+      createId: () => "index",
+    });
+    const index = await indexes.createIndex({ app: "loompad" });
+    await addStoryRootToIndexHandle(index, root.id, {
+      title: "Story",
+      rootText: "Old",
+    });
+
+    await importStoryRootFromLocation(
+      new URL(`https://loompad.test/?story=${encodeURIComponent(root.id)}`) as unknown as Location,
+      { worlds, index },
+    );
+
+    await expect(index.get(root.id)).resolves.toMatchObject({
+      meta: { title: "Story", rootText: "Edited" },
+    });
+  });
+
+  it("rejects unknown shared story ids so callers can fall back to local stories", async () => {
+    const worlds = createMemoryLoomWorlds<{ text: string }, { title: string; rootText: string }>();
+    const indexes = createMemoryLoomIndexes<{ title: string; rootText: string }, { app: "loompad" }>();
+    const index = await indexes.createIndex({ app: "loompad" });
+
+    await expect(
+      importStoryRootFromLocation(
+        new URL("https://loompad.test/?story=memory:missing") as unknown as Location,
+        { worlds, index },
+      ),
+    ).rejects.toThrow("Unknown root");
+    await expect(index.entries()).resolves.toEqual([]);
   });
 });

--- a/client/interface/loomsync/storyRuntime.ts
+++ b/client/interface/loomsync/storyRuntime.ts
@@ -1,0 +1,163 @@
+import { Repo } from "@automerge/automerge-repo";
+import { createAutomergeLoomWorlds } from "../../../vendor/loomsync/packages/core/src/automerge";
+import { createBrowserAutomergeRepo } from "../../../vendor/loomsync/packages/core/src/browser";
+import {
+  createRootShareUrl,
+  getRootIdFromUrl,
+  openRootWithRetry,
+} from "../../../vendor/loomsync/packages/core/src/links";
+import type {
+  LoomWorld,
+  LoomWorlds,
+} from "../../../vendor/loomsync/packages/core/src/types";
+import { createAutomergeLoomIndexes } from "../../../vendor/loomsync/packages/index/src/automerge";
+import {
+  createIndexShareUrl,
+  getIndexIdFromUrl,
+  openIndexWithRetry,
+} from "../../../vendor/loomsync/packages/index/src/links";
+import type { LoomIndex } from "../../../vendor/loomsync/packages/index/src/types";
+import type { TextPayload } from "../../../vendor/loomsync/packages/text/src/types";
+
+export type StoryRootMeta = { title: string; rootText: string };
+export type StoryEntryMeta = { title: string; rootText: string };
+export type StoryWorld = LoomWorld<TextPayload, StoryRootMeta>;
+
+let worlds: LoomWorlds<TextPayload, StoryRootMeta> | null = null;
+let indexes: ReturnType<
+  typeof createAutomergeLoomIndexes<StoryEntryMeta, { app: "loompad" }>
+> | null = null;
+let indexPromise: Promise<LoomIndex<StoryEntryMeta, { app: "loompad" }>> | null =
+  null;
+
+const INDEX_STORAGE_KEY = "loompad-loomsync-index-id";
+
+function createRepo() {
+  if (typeof window === "undefined") return new Repo();
+  return createBrowserAutomergeRepo({
+    indexedDb: { database: "loompad-loomsync", store: "documents" },
+    broadcastChannel: { channelName: "loompad-loomsync" },
+    syncPath: "/loomsync",
+  });
+}
+
+const repo = createRepo();
+
+export function getStoryWorlds(): LoomWorlds<TextPayload, StoryRootMeta> {
+  worlds ??= createAutomergeLoomWorlds<TextPayload, StoryRootMeta>({ repo });
+  return worlds;
+}
+
+function getStoryIndexes() {
+  indexes ??= createAutomergeLoomIndexes<StoryEntryMeta, { app: "loompad" }>({
+    repo,
+  });
+  return indexes;
+}
+
+export async function getStoryIndex(): Promise<
+  LoomIndex<StoryEntryMeta, { app: "loompad" }>
+> {
+  indexPromise ??= (async () => {
+    const storedId =
+      typeof window === "undefined"
+        ? null
+        : window.localStorage.getItem(INDEX_STORAGE_KEY);
+    if (storedId) {
+      try {
+        return await openIndexWithRetry(getStoryIndexes(), storedId);
+      } catch {
+        window.localStorage.removeItem(INDEX_STORAGE_KEY);
+      }
+    }
+    const index = await getStoryIndexes().createIndex({ app: "loompad" });
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(INDEX_STORAGE_KEY, index.id);
+    }
+    return index;
+  })();
+  return indexPromise;
+}
+
+export function getStoryIndexIdFromLocation(location: Location = window.location) {
+  return getIndexIdFromUrl(location);
+}
+
+export function createStoryIndexShareUrl(
+  indexId: string,
+  location: Location = window.location,
+) {
+  return createIndexShareUrl(indexId, location);
+}
+
+export async function importStoryIndexFromUrl(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+  const indexId = getStoryIndexIdFromLocation(window.location);
+  if (!indexId) return null;
+  window.localStorage.setItem(INDEX_STORAGE_KEY, indexId);
+  indexPromise = null;
+  await getStoryIndex();
+  return indexId;
+}
+
+export async function createStoryWorld(title: string, rootText: string) {
+  const storyWorlds = getStoryWorlds();
+  const root = await storyWorlds.createRoot({ title, rootText });
+  const world = await storyWorlds.openRoot(root.id);
+  const index = await getStoryIndex();
+  await index.addRoot(root.id, {
+    title,
+    kind: "story",
+    meta: { title, rootText },
+  });
+  return { root, world };
+}
+
+export function getStoryRootIdFromLocation(location: Location = window.location) {
+  return getRootIdFromUrl(location);
+}
+
+export function createStoryShareUrl(
+  rootId: string,
+  location: Location = window.location,
+) {
+  return createRootShareUrl(rootId, location);
+}
+
+export async function addStoryRootToIndex(
+  rootId: string,
+  meta: StoryEntryMeta,
+): Promise<void> {
+  const index = await getStoryIndex();
+  if (await index.has(rootId)) return;
+  await index.addRoot(rootId, {
+    title: meta.title,
+    kind: "story",
+    meta,
+  });
+}
+
+export async function importStoryRootFromUrl(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+  const rootId = getStoryRootIdFromLocation(window.location);
+  if (!rootId) return null;
+  const world = await openStoryWorld(rootId);
+  const root = await world.root();
+  await addStoryRootToIndex(rootId, {
+    title: root.meta?.title ?? "Shared Story",
+    rootText: root.meta?.rootText ?? "",
+  });
+  return rootId;
+}
+
+export async function listStoryEntries() {
+  return (await getStoryIndex()).entries();
+}
+
+export async function openStoryWorld(rootId: string): Promise<StoryWorld> {
+  return openRootWithRetry(getStoryWorlds(), rootId);
+}
+
+export async function removeStory(rootId: string): Promise<void> {
+  await (await getStoryIndex()).removeRoot(rootId);
+}

--- a/client/interface/loomsync/storyRuntime.ts
+++ b/client/interface/loomsync/storyRuntime.ts
@@ -128,8 +128,22 @@ export async function addStoryRootToIndex(
   rootId: string,
   meta: StoryEntryMeta,
 ): Promise<void> {
-  const index = await getStoryIndex();
-  if (await index.has(rootId)) return;
+  await addStoryRootToIndexHandle(await getStoryIndex(), rootId, meta);
+}
+
+export async function addStoryRootToIndexHandle(
+  index: LoomIndex<StoryEntryMeta, { app: "loompad" }>,
+  rootId: string,
+  meta: StoryEntryMeta,
+): Promise<void> {
+  if (await index.has(rootId)) {
+    await index.updateRoot(rootId, {
+      title: meta.title,
+      kind: "story",
+      meta,
+    });
+    return;
+  }
   await index.addRoot(rootId, {
     title: meta.title,
     kind: "story",
@@ -139,11 +153,24 @@ export async function addStoryRootToIndex(
 
 export async function importStoryRootFromUrl(): Promise<string | null> {
   if (typeof window === "undefined") return null;
-  const rootId = getStoryRootIdFromLocation(window.location);
+  return importStoryRootFromLocation(window.location, {
+    worlds: getStoryWorlds(),
+    index: await getStoryIndex(),
+  });
+}
+
+export async function importStoryRootFromLocation(
+  location: Location,
+  options: {
+    worlds: LoomWorlds<TextPayload, StoryRootMeta>;
+    index: LoomIndex<StoryEntryMeta, { app: "loompad" }>;
+  },
+): Promise<string | null> {
+  const rootId = getStoryRootIdFromLocation(location);
   if (!rootId) return null;
-  const world = await openStoryWorld(rootId);
+  const world = await openRootWithRetry(options.worlds, rootId);
   const root = await world.root();
-  await addStoryRootToIndex(rootId, {
+  await addStoryRootToIndexHandle(options.index, rootId, {
     title: root.meta?.title ?? "Shared Story",
     rootText: root.meta?.rootText ?? "",
   });

--- a/client/interface/loomsync/storySessionState.test.ts
+++ b/client/interface/loomsync/storySessionState.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getPreferredChildIndex,
+  setPreferredChildIndex,
+} from "./storySessionState";
+
+describe("story session state", () => {
+  it("keeps preferred child selection outside story world data", () => {
+    setPreferredChildIndex("story", "node", 2);
+    expect(getPreferredChildIndex("story", "node", 3, 0)).toBe(2);
+    expect(getPreferredChildIndex("story", "node", 2, 0)).toBe(0);
+  });
+});

--- a/client/interface/loomsync/storySessionState.ts
+++ b/client/interface/loomsync/storySessionState.ts
@@ -1,0 +1,68 @@
+export interface StorySessionState {
+  preferredChildByNode: Record<string, number>;
+}
+
+const memoryState = new Map<string, StorySessionState>();
+
+const storageKey = (storyKey: string) => `loompad-story-session:${storyKey}`;
+
+const canUseSessionStorage = () =>
+  typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
+
+export function getStorySessionState(storyKey: string): StorySessionState {
+  if (!canUseSessionStorage()) {
+    return memoryState.get(storyKey) ?? { preferredChildByNode: {} };
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(storageKey(storyKey));
+    if (!raw) return { preferredChildByNode: {} };
+    const parsed = JSON.parse(raw) as Partial<StorySessionState>;
+    return { preferredChildByNode: parsed.preferredChildByNode ?? {} };
+  } catch {
+    return { preferredChildByNode: {} };
+  }
+}
+
+export function setStorySessionState(
+  storyKey: string,
+  state: StorySessionState,
+): void {
+  memoryState.set(storyKey, state);
+
+  if (!canUseSessionStorage()) return;
+  try {
+    window.sessionStorage.setItem(storageKey(storyKey), JSON.stringify(state));
+  } catch {
+    // Session state is best-effort and must not affect shared world correctness.
+  }
+}
+
+export function getPreferredChildIndex(
+  storyKey: string,
+  nodeId: string,
+  childCount: number,
+  fallback = 0,
+): number {
+  const preferred = getStorySessionState(storyKey).preferredChildByNode[nodeId];
+  return typeof preferred === "number" &&
+    preferred >= 0 &&
+    preferred < childCount
+    ? preferred
+    : fallback;
+}
+
+export function setPreferredChildIndex(
+  storyKey: string,
+  nodeId: string,
+  index: number,
+): void {
+  const state = getStorySessionState(storyKey);
+  setStorySessionState(storyKey, {
+    ...state,
+    preferredChildByNode: {
+      ...state.preferredChildByNode,
+      [nodeId]: index,
+    },
+  });
+}

--- a/client/interface/menus/TreeListMenu.tsx
+++ b/client/interface/menus/TreeListMenu.tsx
@@ -33,6 +33,22 @@ const PrintIcon = () => (
   </svg>
 );
 
+const LinkIcon = () => (
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    className="story-menu-icon"
+  >
+    <path
+      d="M6.2 10.9 5.1 12a2.1 2.1 0 0 1-3-3l2.4-2.4a2.1 2.1 0 0 1 3 0l.6.6-.9.9-.6-.6a.9.9 0 0 0-1.2 0L3 9.9a.9.9 0 0 0 1.2 1.2l1.1-1.1.9.9zm3.6-5.8L10.9 4a2.1 2.1 0 0 1 3 3l-2.4 2.4a2.1 2.1 0 0 1-3 0l-.6-.6.9-.9.6.6a.9.9 0 0 0 1.2 0L13 6.1a.9.9 0 0 0-1.2-1.2l-1.1 1.1-.9-.9zM5.6 9.5l3.9-3.9.9.9-3.9 3.9-.9-.9z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const TreeListMenu = ({
   trees,
   selectedIndex,
@@ -41,15 +57,18 @@ export const TreeListMenu = ({
   onNew,
   onExportJson,
   onExportThread,
+  onShareStory,
+  onShareIndex,
   onHighlight,
 }: TreeListProps) => {
   const treeEntries = sortTreeEntriesByRecency(trees);
 
-  const actionColumns: Array<"story" | "json" | "thread"> = ["story"];
+  const actionColumns: Array<"story" | "share" | "json" | "thread"> = ["story"];
+  if (onShareStory) actionColumns.push("share");
   if (onExportJson) actionColumns.push("json");
   if (onExportThread) actionColumns.push("thread");
 
-  const getColumnIndex = (action: "json" | "thread") =>
+  const getColumnIndex = (action: "share" | "json" | "thread") =>
     actionColumns.indexOf(action);
 
   return (
@@ -71,6 +90,24 @@ export const TreeListMenu = ({
           <div className="menu-item-body">
             <div className="menu-item-label">+ New Story</div>
           </div>
+          {onShareIndex ? (
+            <button
+              type="button"
+              className="story-menu-action"
+              title="Copy all stories link"
+              aria-label="Copy all stories link"
+              onClick={(event) => {
+                event.stopPropagation();
+                onShareIndex();
+                onHighlight?.(0, 1);
+              }}
+              onMouseEnter={() => onHighlight?.(0, 1)}
+              onFocus={() => onHighlight?.(0, 1)}
+            >
+              <LinkIcon />
+              <span className="visually-hidden">Copy all stories link</span>
+            </button>
+          ) : null}
         </div>
       </div>
 
@@ -78,6 +115,7 @@ export const TreeListMenu = ({
         const rowIndex = index + 1;
         const isStorySelected =
           selectedIndex === rowIndex && selectedColumn === 0;
+        const shareColumn = getColumnIndex("share");
         const saveColumn = getColumnIndex("json");
         const printColumn = getColumnIndex("thread");
 
@@ -103,12 +141,35 @@ export const TreeListMenu = ({
                 </div>
               </div>
 
-              {onExportJson || onExportThread ? (
+              {onShareStory || onExportJson || onExportThread ? (
                 <div
                   className="story-menu-actions"
                   role="group"
-                  aria-label="Story export options"
+                  aria-label="Story actions"
                 >
+                  {onShareStory ? (
+                    <button
+                      type="button"
+                      className={`story-menu-action ${
+                        selectedIndex === rowIndex && selectedColumn === shareColumn
+                          ? "selected"
+                          : ""
+                      }`}
+                      title="Copy story link"
+                      aria-label="Copy story link"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onShareStory(key);
+                        onHighlight?.(rowIndex, shareColumn);
+                      }}
+                      onMouseEnter={() => onHighlight?.(rowIndex, shareColumn)}
+                      onFocus={() => onHighlight?.(rowIndex, shareColumn)}
+                    >
+                      <LinkIcon />
+                      <span className="visually-hidden">Copy story link</span>
+                    </button>
+                  ) : null}
+
                   {onExportJson ? (
                     <button
                       type="button"

--- a/client/interface/types/index.ts
+++ b/client/interface/types/index.ts
@@ -75,6 +75,8 @@ export interface TreeListProps {
   onNew?: () => void;
   onExportJson?: (key: string) => void;
   onExportThread?: (key: string) => void;
+  onShareStory?: (key: string) => void;
+  onShareIndex?: () => void;
   onHighlight?: (index: number, column: number) => void;
 }
 

--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import tailwindcss from "@tailwindcss/postcss";
+import wasm from "vite-plugin-wasm";
+import topLevelAwait from "vite-plugin-top-level-await";
 
 if (process.env.NODE_ENV !== "production") {
   console.log("Loading vite config from config/vite.config.ts...");
@@ -14,6 +16,8 @@ const mode = "production";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
+    wasm(),
+    topLevelAwait(),
     react(),
     VitePWA({
       registerType: "autoUpdate",
@@ -88,6 +92,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ["srcl"],
+    include: ["eventemitter3"],
+    exclude: ["srcl", "@automerge/automerge"],
   },
 });

--- a/package.json
+++ b/package.json
@@ -9,9 +9,14 @@
     "build": "vite build --outDir=dist/server --ssr server/ssr.tsx  --config config/vite.config.ts && vite build --outDir=dist/client --config config/vite.config.ts",
     "prod": "bun run.ts --mode=production",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "test": "bun test"
+    "test": "bun test",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@automerge/automerge-repo": "^2.5.5",
+    "@automerge/automerge-repo-network-broadcastchannel": "^2.5.5",
+    "@automerge/automerge-repo-network-websocket": "^2.5.5",
+    "@automerge/automerge-repo-storage-indexeddb": "^2.5.5",
     "@ax-llm/ax": "^14.0.39",
     "@tailwindcss/postcss": "^4.1.17",
     "@types/d3-flextree": "^2.1.4",
@@ -25,6 +30,7 @@
     "d3-flextree": "^2.1.2",
     "d3-hierarchy": "^3.1.2",
     "express": "^4.19.2",
+    "isomorphic-ws": "^5.0.0",
     "nocache": "^4.0.0",
     "nodemon": "^3.1.0",
     "openai": "^4.77.0",
@@ -33,10 +39,12 @@
     "srcl": "github:deepfates/srcl",
     "styled-components": "^6.1.8",
     "tailwindcss": "^4.1.17",
+    "uuid": "^14.0.0",
     "wouter": "^3.3.5",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@rollup/rollup-linux-x64-gnu": "^4.52.4",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
@@ -48,6 +56,8 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.2.2",
     "vite": "^5.2.8",
-    "vite-plugin-pwa": "^1.0.1"
+    "vite-plugin-pwa": "^1.0.1",
+    "vite-plugin-top-level-await": "^1.6.0",
+    "vite-plugin-wasm": "^3.6.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: "**/*.pw.ts",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "bun run build && bun run prod",
+    url: "http://127.0.0.1:5173",
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/server/loomsync.ts
+++ b/server/loomsync.ts
@@ -1,0 +1,16 @@
+import type http from "http";
+import path from "path";
+import { attachLoomSyncServer as attachVendoredLoomSyncServer } from "../vendor/loomsync/packages/sync-server/src/index";
+
+let attached = false;
+
+export function attachLoomSyncServer(server: http.Server) {
+  if (attached) return;
+  attached = true;
+  attachVendoredLoomSyncServer(server, {
+    path: "/loomsync",
+    storageDir:
+      process.env.LOOMSYNC_STORAGE_DIR ??
+      path.resolve(process.cwd(), ".data/loomsync"),
+  });
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -6,11 +6,13 @@ import http from "http";
 import { createServer as createViteServer } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/postcss";
+import wasm from "vite-plugin-wasm";
 
 // app specific imports
 import args from "server/args";
 import { setup_routes } from "server/apis/http";
 import { getMainProps } from "server/main_props";
+import { attachLoomSyncServer } from "server/loomsync";
 
 const port: number = args.port;
 const mode: "development" | "production" = args.mode;
@@ -39,6 +41,7 @@ export async function createServer() {
   const app = express();
 
   const http_server = http.createServer(app);
+  attachLoomSyncServer(http_server);
   setup_routes(app);
 
   let vite;
@@ -47,7 +50,7 @@ export async function createServer() {
       configFile: false, // Don't load config file - use inline config only
       root: path.resolve(__dirname, "../"),
       appType: "custom",
-      plugins: [react()],
+      plugins: [wasm(), react()],
       css: {
         postcss: {
           plugins: [tailwindcss()],
@@ -67,7 +70,8 @@ export async function createServer() {
         },
       },
       optimizeDeps: {
-        exclude: ["srcl"],
+        include: ["eventemitter3"],
+        exclude: ["srcl", "@automerge/automerge"],
       },
       server: {
         middlewareMode: true,

--- a/tests/e2e/loomsync-story.pw.ts
+++ b/tests/e2e/loomsync-story.pw.ts
@@ -1,0 +1,108 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const generatedText = " The bronze door opened.";
+
+async function mockGeneration(page: Page, text = generatedText) {
+  await page.route("**/api/generate", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      },
+      body: `data: ${JSON.stringify({ content: text })}\n\ndata: [DONE]\n\n`,
+    });
+  });
+  await page.route("**/api/judge", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ choice: 0 }),
+    });
+  });
+}
+
+async function openStoriesMenu(page: Page) {
+  await page.getByRole("button", { name: "START" }).click();
+  await expect(page.getByText("MAP", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "SELECT" }).click();
+  await expect(page.getByText("STORIES", { exact: true })).toBeVisible();
+}
+
+async function currentStoryRootId(page: Page): Promise<string> {
+  await openStoriesMenu(page);
+  const label = page
+    .locator(".menu-item-label")
+    .filter({ hasText: /^automerge:/ })
+    .first();
+  await expect(label).toBeVisible();
+  return (await label.textContent()) ?? "";
+}
+
+async function currentStoryIndexId(page: Page): Promise<string> {
+  const indexId = await page.evaluate(() =>
+    window.localStorage.getItem("loompad-loomsync-index-id"),
+  );
+  expect(indexId).toBeTruthy();
+  return indexId ?? "";
+}
+
+async function closeStoriesMenuToLoom(page: Page) {
+  await page.getByRole("button", { name: "START" }).click();
+  await expect(page.getByText("MAP", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "START" }).click();
+  await expect(page.getByText("LOOM", { exact: true })).toBeVisible();
+}
+
+test("creates, syncs, persists, and shares a LoomSync story world", async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await mockGeneration(page);
+
+  await page.goto("/");
+  await expect(page.getByLabel("Story Interface")).toBeVisible();
+  await expect(page.locator(".story-text")).toContainText(
+    "Once upon a time, in Absalom,",
+  );
+
+  const rootId = await currentStoryRootId(page);
+  expect(rootId).toMatch(/^automerge:/);
+  const indexId = await currentStoryIndexId(page);
+  expect(indexId).toMatch(/^automerge:/);
+  await closeStoriesMenuToLoom(page);
+
+  const sameBrowserPage = await context.newPage();
+  await mockGeneration(sameBrowserPage);
+  await sameBrowserPage.goto(`/?story=${encodeURIComponent(rootId)}`);
+  await expect(sameBrowserPage.locator(".story-text")).toContainText(
+    "Once upon a time, in Absalom,",
+  );
+
+  await page.getByRole("button", { name: "↵" }).click();
+  await expect(page.locator(".story-text")).toContainText(generatedText.trim());
+  await expect(sameBrowserPage.locator(".story-text")).toContainText(
+    generatedText.trim(),
+  );
+
+  await page.reload();
+  await expect(page.locator(".story-text")).toContainText(generatedText.trim());
+
+  const otherBrowserContext = await browser.newContext();
+  const sharedPage = await otherBrowserContext.newPage();
+  await mockGeneration(sharedPage);
+  await sharedPage.goto(`/?story=${encodeURIComponent(rootId)}`);
+  await expect(sharedPage.locator(".story-text")).toContainText(
+    generatedText.trim(),
+  );
+
+  const sharedIndexPage = await otherBrowserContext.newPage();
+  await mockGeneration(sharedIndexPage);
+  await sharedIndexPage.goto(`/?index=${encodeURIComponent(indexId)}`);
+  await openStoriesMenu(sharedIndexPage);
+  await expect(
+    sharedIndexPage.locator(".menu-item-label").filter({ hasText: rootId }),
+  ).toBeVisible();
+
+  await otherBrowserContext.close();
+  await context.close();
+});

--- a/vendor/loomsync/.gitignore
+++ b/vendor/loomsync/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store

--- a/vendor/loomsync/README.md
+++ b/vendor/loomsync/README.md
@@ -1,0 +1,40 @@
+# LoomSync
+
+LoomSync is a TypeScript workspace for local-first branching worlds.
+
+## Packages
+
+- `@loomsync/core`: one append-only rooted branching world.
+- `@loomsync/index`: an index document that links to many worlds.
+- `@loomsync/text`: helpers for text payload worlds.
+
+The current implementation includes in-memory backends and shared interfaces. The
+Automerge-backed backend is the next implementation target.
+
+## Browser Bundling
+
+Automerge uses a WASM bundle. Vite consumers should include:
+
+```ts
+import wasm from "vite-plugin-wasm";
+import topLevelAwait from "vite-plugin-top-level-await";
+
+export default defineConfig({
+  plugins: [wasm(), topLevelAwait()],
+});
+```
+
+Packages expose subpaths so apps can import only the surface they need:
+
+```ts
+import { createAutomergeLoomWorlds } from "@loomsync/core/automerge";
+import type { LoomWorld } from "@loomsync/core/types";
+```
+
+## Development
+
+```bash
+pnpm install
+pnpm test
+pnpm build
+```

--- a/vendor/loomsync/ROADMAP.md
+++ b/vendor/loomsync/ROADMAP.md
@@ -1,0 +1,29 @@
+# LoomSync Roadmap
+
+## Verification Loop
+
+Run this after each implementation slice:
+
+```bash
+pnpm verify
+```
+
+`verify` runs tests, builds packages, and typechecks emitted package surfaces.
+
+## Current Plan
+
+- [x] Create standalone TypeScript workspace.
+- [x] Define `core`, `index`, and `text` package boundaries.
+- [x] Implement in-memory `core` backend.
+- [x] Implement in-memory `index` backend.
+- [x] Implement text helpers for Loompad migration.
+- [x] Add meaningful topology, index, and text tests.
+- [x] Add Automerge document schema for `core`.
+- [x] Implement Automerge `createRoot`, `openRoot`, `appendAfter`, and queries.
+- [x] Add Automerge export/import validation.
+- [x] Add Automerge subscription event translation.
+- [x] Add browser adapter factory for IndexedDB + BroadcastChannel + WebSocket.
+- [x] Implement Automerge-backed `index`.
+- [x] Add WebSocket sync relay package or example.
+- [x] Add Loompad compatibility adapter/hook examples.
+- [x] Add package subpath exports from Loompad integration feedback.

--- a/vendor/loomsync/SPEC.md
+++ b/vendor/loomsync/SPEC.md
@@ -1,0 +1,33 @@
+# LoomSync v0.1 Spec
+
+## Package Boundaries
+
+`@loomsync/core` models one shared branching world. A world has one root,
+append-only nodes, canonical sibling order, path reconstruction, leaves,
+subscriptions, and deterministic import/export.
+
+`@loomsync/index` models a linked index of worlds. It stores links to roots and
+lightweight display metadata. It does not embed world content.
+
+`@loomsync/text` provides helpers for text payload worlds, including path
+flattening and appending chains of text chunks.
+
+## Root Identity
+
+In the Automerge backend, `LoomRoot.id` is the Automerge document URL. Sharing a
+world means sharing that root ID.
+
+Snapshot import preserves node IDs and parent IDs but creates a new root ID in
+the target backend.
+
+## Shared Content Boundary
+
+Core and index packages store durable shared content only. Cursor position,
+preferred branch, minimap focus, draft text, selection, and presence belong to
+host applications.
+
+## Deferred Backends
+
+The in-memory backend is implemented first to prove API semantics and tests.
+The Automerge backend must satisfy the same interfaces with IndexedDB,
+BroadcastChannel, and optional WebSocket sync.

--- a/vendor/loomsync/package.json
+++ b/vendor/loomsync/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "loomsync-workspace",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@9.15.0",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "pnpm -r build",
+    "test": "vitest run",
+    "typecheck": "pnpm build && pnpm -r typecheck",
+    "verify": "pnpm test && pnpm typecheck"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.1"
+  },
+  "dependencies": {
+    "@automerge/automerge-repo": "^2.5.5",
+    "@automerge/automerge-repo-network-broadcastchannel": "^2.5.5",
+    "@automerge/automerge-repo-network-websocket": "^2.5.5",
+    "@automerge/automerge-repo-storage-indexeddb": "^2.5.5",
+    "@types/ws": "^8.18.1",
+    "isomorphic-ws": "^5.0.0",
+    "uuid": "^14.0.0"
+  }
+}

--- a/vendor/loomsync/packages/core/package.json
+++ b/vendor/loomsync/packages/core/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@loomsync/core",
+  "version": "0.1.0",
+  "description": "Core APIs for append-only rooted branching worlds.",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./automerge": {
+      "types": "./dist/automerge.d.ts",
+      "import": "./dist/automerge.js",
+      "default": "./dist/automerge.js"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js",
+      "default": "./dist/browser.js"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "import": "./dist/errors.js",
+      "default": "./dist/errors.js"
+    },
+    "./links": {
+      "types": "./dist/links.d.ts",
+      "import": "./dist/links.js",
+      "default": "./dist/links.js"
+    },
+    "./memory": {
+      "types": "./dist/memory.d.ts",
+      "import": "./dist/memory.js",
+      "default": "./dist/memory.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js",
+      "default": "./dist/types.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/vendor/loomsync/packages/core/src/automerge.ts
+++ b/vendor/loomsync/packages/core/src/automerge.ts
@@ -1,0 +1,330 @@
+import { DocHandle, Repo, type AutomergeUrl } from "@automerge/automerge-repo";
+import {
+  brokenTopology,
+  closedHandle,
+  cycleDetected,
+  duplicateNodeId,
+  missingParent,
+  unknownRoot,
+} from "./errors.js";
+import { assertJsonEncodable, cloneJson } from "./json.js";
+import type {
+  LoomNode,
+  LoomNodeId,
+  LoomRoot,
+  LoomRootId,
+  LoomSnapshot,
+  LoomWorld,
+  LoomWorldEvent,
+  LoomWorldListener,
+  LoomWorlds,
+} from "./types.js";
+
+const ROOT_CHILDREN_KEY = "__root__";
+
+type LoomDoc<TPayload, TRootMeta, TNodeMeta> = {
+  version: 1;
+  root: LoomRoot<TRootMeta>;
+  nodes: Record<LoomNodeId, LoomNode<TPayload, TNodeMeta>>;
+  children: Record<string, LoomNodeId[]>;
+};
+
+export interface AutomergeLoomWorldsOptions {
+  repo?: Repo;
+  createNodeId?: () => string;
+  now?: () => number;
+}
+
+export function createAutomergeLoomWorlds<
+  TPayload = unknown,
+  TRootMeta = unknown,
+  TNodeMeta = unknown,
+>(
+  options: AutomergeLoomWorldsOptions = {},
+): LoomWorlds<TPayload, TRootMeta, TNodeMeta> {
+  const repo = options.repo ?? new Repo();
+  const createNodeId = options.createNodeId ?? (() => crypto.randomUUID());
+  const now = options.now ?? (() => Date.now());
+
+  return {
+    async createRoot(meta) {
+      assertJsonEncodable(meta, "root meta");
+      const handle = repo.create<LoomDoc<TPayload, TRootMeta, TNodeMeta>>({
+        version: 1,
+        root: {
+          id: "" as LoomRootId,
+          ...(meta === undefined ? {} : { meta: cloneJson(meta) }),
+          createdAt: now(),
+        },
+        nodes: {},
+        children: { [ROOT_CHILDREN_KEY]: [] },
+      });
+      handle.change((doc) => {
+        doc.root.id = handle.url;
+      });
+      return cloneJson(handle.doc().root);
+    },
+
+    async getRoot(rootId) {
+      try {
+        const handle = await repo.find<LoomDoc<TPayload, TRootMeta, TNodeMeta>>(
+          rootId as AutomergeUrl,
+        );
+        await handle.whenReady();
+        return cloneJson(handle.doc().root);
+      } catch {
+        return null;
+      }
+    },
+
+    async openRoot(rootId) {
+      let handle: DocHandle<LoomDoc<TPayload, TRootMeta, TNodeMeta>>;
+      try {
+        handle = await repo.find<LoomDoc<TPayload, TRootMeta, TNodeMeta>>(
+          rootId as AutomergeUrl,
+        );
+        await handle.whenReady();
+      } catch {
+        throw unknownRoot(rootId);
+      }
+      return new AutomergeLoomWorld(rootId, handle, createNodeId, now);
+    },
+
+    async importRoot(snapshot) {
+      validateSnapshot(snapshot);
+      const handle = repo.create<LoomDoc<TPayload, TRootMeta, TNodeMeta>>({
+        version: 1,
+        root: {
+          id: "" as LoomRootId,
+          ...(snapshot.root.meta === undefined ? {} : { meta: cloneJson(snapshot.root.meta) }),
+          createdAt: snapshot.root.createdAt,
+        },
+        nodes: {},
+        children: { [ROOT_CHILDREN_KEY]: [] },
+      });
+      handle.change((doc) => {
+        doc.root.id = handle.url;
+        for (const imported of snapshot.nodes) {
+          const node = {
+            ...cloneJson(imported),
+            rootId: handle.url,
+          };
+          doc.nodes[node.id] = node;
+          doc.children[node.id] ??= [];
+          const key = parentKeyOf(node.parentId);
+          doc.children[key] ??= [];
+          doc.children[key].push(node.id);
+        }
+      });
+      return cloneJson(handle.doc().root);
+    },
+  };
+}
+
+class AutomergeLoomWorld<TPayload, TRootMeta, TNodeMeta>
+  implements LoomWorld<TPayload, TRootMeta, TNodeMeta>
+{
+  private closed = false;
+  private listeners = new Set<LoomWorldListener<TPayload, TRootMeta, TNodeMeta>>();
+  private knownNodeIds: Set<LoomNodeId>;
+
+  constructor(
+    readonly id: LoomRootId,
+    private readonly handle: DocHandle<LoomDoc<TPayload, TRootMeta, TNodeMeta>>,
+    private readonly createNodeId: () => string,
+    private readonly now: () => number,
+  ) {
+    this.knownNodeIds = new Set(Object.keys(this.handle.doc().nodes ?? {}));
+    this.handle.on("change", ({ doc }) => {
+      const currentIds = new Set(Object.keys(doc.nodes ?? {}));
+      for (const nodeId of currentIds) {
+        if (!this.knownNodeIds.has(nodeId)) {
+          const node = doc.nodes[nodeId];
+          if (node) this.emit({ type: "node-added", rootId: this.id, node: cloneJson(node) });
+        }
+      }
+      this.knownNodeIds = currentIds;
+    });
+  }
+
+  async root(): Promise<LoomRoot<TRootMeta>> {
+    this.assertOpen();
+    return cloneJson(this.doc().root);
+  }
+
+  async updateRootMeta(meta: TRootMeta): Promise<LoomRoot<TRootMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(meta, "root meta");
+    this.handle.change((doc) => {
+      doc.root.meta = cloneJson(meta) as TRootMeta;
+    });
+    const root = cloneJson(this.doc().root);
+    this.emit({ type: "root-updated", root });
+    return root;
+  }
+
+  async appendAfter(
+    parentId: LoomNodeId | null,
+    payload: TPayload,
+    meta?: TNodeMeta,
+  ): Promise<LoomNode<TPayload, TNodeMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(payload, "node payload");
+    assertJsonEncodable(meta, "node meta");
+    if (parentId !== null && !this.doc().nodes[parentId]) throw missingParent(parentId);
+
+    const nodeId = this.createNodeId();
+    if (nodeId === ROOT_CHILDREN_KEY || this.doc().nodes[nodeId]) throw duplicateNodeId(nodeId);
+
+    const node = omitUndefined({
+      id: nodeId,
+      rootId: this.id,
+      parentId,
+      payload: cloneJson(payload),
+      meta: cloneJson(meta),
+      createdAt: this.now(),
+    }) as LoomNode<TPayload, TNodeMeta>;
+
+    this.handle.change((doc) => {
+      doc.nodes[node.id] = node;
+      doc.children[node.id] ??= [];
+      const key = parentKeyOf(parentId);
+      doc.children[key] ??= [];
+      doc.children[key].push(node.id);
+    });
+
+    return cloneJson(node);
+  }
+
+  async getNode(nodeId: LoomNodeId): Promise<LoomNode<TPayload, TNodeMeta> | null> {
+    this.assertOpen();
+    const node = this.doc().nodes[nodeId];
+    return node ? cloneJson(node) : null;
+  }
+
+  async hasNode(nodeId: LoomNodeId): Promise<boolean> {
+    this.assertOpen();
+    return Boolean(this.doc().nodes[nodeId]);
+  }
+
+  async childrenOf(parentId: LoomNodeId | null): Promise<LoomNode<TPayload, TNodeMeta>[]> {
+    this.assertOpen();
+    const doc = this.doc();
+    if (parentId !== null && !doc.nodes[parentId]) throw missingParent(parentId);
+    return (doc.children[parentKeyOf(parentId)] ?? []).map((nodeId) => {
+      const node = doc.nodes[nodeId];
+      if (!node) throw brokenTopology(`Child list references missing node: ${nodeId}`);
+      return cloneJson(node);
+    });
+  }
+
+  async pathTo(nodeId: LoomNodeId): Promise<LoomNode<TPayload, TNodeMeta>[]> {
+    this.assertOpen();
+    const doc = this.doc();
+    const path: LoomNode<TPayload, TNodeMeta>[] = [];
+    const seen = new Set<LoomNodeId>();
+    let currentId: LoomNodeId | null = nodeId;
+
+    while (currentId !== null) {
+      if (seen.has(currentId)) throw cycleDetected(currentId);
+      seen.add(currentId);
+      const node: LoomNode<TPayload, TNodeMeta> | undefined = doc.nodes[currentId];
+      if (!node) throw brokenTopology(`Path references missing node: ${currentId}`);
+      path.push(node);
+      currentId = node.parentId;
+    }
+
+    return cloneJson(path.reverse());
+  }
+
+  async leaves(): Promise<LoomNode<TPayload, TNodeMeta>[]> {
+    this.assertOpen();
+    const doc = this.doc();
+    const leaves: LoomNode<TPayload, TNodeMeta>[] = [];
+    const visit = (parentId: LoomNodeId | null) => {
+      for (const nodeId of doc.children[parentKeyOf(parentId)] ?? []) {
+        const node = doc.nodes[nodeId];
+        if (!node) throw brokenTopology(`Child list references missing node: ${nodeId}`);
+        if ((doc.children[nodeId] ?? []).length === 0) {
+          leaves.push(node);
+        } else {
+          visit(nodeId);
+        }
+      }
+    };
+    visit(null);
+    return cloneJson(leaves);
+  }
+
+  subscribe(listener: LoomWorldListener<TPayload, TRootMeta, TNodeMeta>): () => void {
+    this.assertOpen();
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async export(): Promise<LoomSnapshot<TPayload, TRootMeta, TNodeMeta>> {
+    this.assertOpen();
+    const doc = this.doc();
+    const nodes: LoomNode<TPayload, TNodeMeta>[] = [];
+    const visit = (parentId: LoomNodeId | null) => {
+      for (const nodeId of doc.children[parentKeyOf(parentId)] ?? []) {
+        const node = doc.nodes[nodeId];
+        if (!node) throw brokenTopology(`Child list references missing node: ${nodeId}`);
+        nodes.push(node);
+        visit(nodeId);
+      }
+    };
+    visit(null);
+    return cloneJson({ root: doc.root, nodes });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.listeners.clear();
+  }
+
+  private doc() {
+    return this.handle.doc();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw closedHandle();
+  }
+
+  private emit(event: LoomWorldEvent<TPayload, TRootMeta, TNodeMeta>): void {
+    for (const listener of this.listeners) listener(event);
+  }
+}
+
+function validateSnapshot(snapshot: LoomSnapshot<unknown, unknown, unknown>): void {
+  const ids = new Set<LoomNodeId>();
+  for (const node of snapshot.nodes) {
+    if (node.id === ROOT_CHILDREN_KEY) throw duplicateNodeId(node.id);
+    if (ids.has(node.id)) throw duplicateNodeId(node.id);
+    ids.add(node.id);
+  }
+  for (const node of snapshot.nodes) {
+    if (node.parentId !== null && !ids.has(node.parentId)) throw missingParent(node.parentId);
+  }
+  for (const node of snapshot.nodes) {
+    const seen = new Set<LoomNodeId>();
+    let currentId: LoomNodeId | null = node.id;
+    while (currentId !== null) {
+      if (seen.has(currentId)) throw cycleDetected(currentId);
+      seen.add(currentId);
+      const current = snapshot.nodes.find((candidate) => candidate.id === currentId);
+      if (!current) throw brokenTopology(`Missing node while validating path: ${currentId}`);
+      currentId = current.parentId;
+    }
+  }
+}
+
+function parentKeyOf(parentId: LoomNodeId | null): string {
+  return parentId ?? ROOT_CHILDREN_KEY;
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T;
+}

--- a/vendor/loomsync/packages/core/src/browser.ts
+++ b/vendor/loomsync/packages/core/src/browser.ts
@@ -1,0 +1,104 @@
+import { Repo, type RepoConfig } from "@automerge/automerge-repo";
+import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-indexeddb";
+import { BroadcastChannelNetworkAdapter } from "@automerge/automerge-repo-network-broadcastchannel";
+import { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
+
+type StorageConstructor = new (database?: string, store?: string) => unknown;
+type BroadcastConstructor = new (options?: {
+  channelName: string;
+  peerWaitMs?: number;
+}) => unknown;
+type WebSocketConstructor = new (url: string, retryInterval?: number) => unknown;
+
+export interface BrowserAutomergeRepoOptions {
+  location?: Pick<Location, "protocol" | "host">;
+  syncPath?: string;
+  indexedDb?: false | {
+    database?: string;
+    store?: string;
+  };
+  broadcastChannel?: false | {
+    channelName?: string;
+    peerWaitMs?: number;
+  };
+  websocket?: false | true | {
+    url: string;
+    retryInterval?: number;
+  };
+  adapters?: {
+    IndexedDBStorageAdapter?: StorageConstructor;
+    BroadcastChannelNetworkAdapter?: BroadcastConstructor;
+    WebSocketClientAdapter?: WebSocketConstructor;
+  };
+}
+
+export function createBrowserAutomergeRepo(options: BrowserAutomergeRepoOptions = {}): Repo {
+  return new Repo(createBrowserAutomergeRepoConfig(options) as RepoConfig);
+}
+
+export function createBrowserAutomergeRepoConfig(
+  options: BrowserAutomergeRepoOptions = {},
+): {
+  storage?: unknown;
+  network: unknown[];
+} {
+  const IndexedDB =
+    options.adapters?.IndexedDBStorageAdapter ?? IndexedDBStorageAdapter;
+  const Broadcast =
+    options.adapters?.BroadcastChannelNetworkAdapter ?? BroadcastChannelNetworkAdapter;
+  const WebSocket =
+    options.adapters?.WebSocketClientAdapter ?? WebSocketClientAdapter;
+
+  const indexedDbOptions = options.indexedDb ?? {};
+  const broadcastOptions = options.broadcastChannel ?? {};
+  const websocketOptions = options.websocket ?? true;
+
+  const network = [];
+  if (broadcastOptions !== false) {
+    network.push(
+      new Broadcast({
+        channelName: broadcastOptions.channelName ?? "loomsync",
+        peerWaitMs: broadcastOptions.peerWaitMs,
+      }),
+    );
+  }
+  if (websocketOptions !== false) {
+    const websocketUrl =
+      websocketOptions === true
+        ? defaultWebSocketUrl({
+            location: options.location,
+            path: options.syncPath,
+          })
+        : websocketOptions.url;
+    const retryInterval =
+      websocketOptions === true ? undefined : websocketOptions.retryInterval;
+    if (websocketUrl) network.push(new WebSocket(websocketUrl, retryInterval));
+  }
+
+  return {
+    storage:
+      indexedDbOptions === false
+        ? undefined
+        : new IndexedDB(indexedDbOptions.database, indexedDbOptions.store),
+    network,
+  };
+}
+
+export interface DefaultWebSocketUrlOptions {
+  location?: Pick<Location, "protocol" | "host">;
+  path?: string;
+}
+
+export function defaultWebSocketUrl(options: DefaultWebSocketUrlOptions = {}) {
+  const location =
+    options.location ??
+    (typeof window === "undefined" ? undefined : window.location);
+  if (!location) return null;
+  const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+  const path = normalizeSyncPath(options.path ?? "/loomsync");
+  return `${protocol}//${location.host}${path}`;
+}
+
+function normalizeSyncPath(path: string) {
+  return path.startsWith("/") ? path : `/${path}`;
+}

--- a/vendor/loomsync/packages/core/src/errors.ts
+++ b/vendor/loomsync/packages/core/src/errors.ts
@@ -1,0 +1,46 @@
+export type LoomErrorCode =
+  | "UNKNOWN_ROOT"
+  | "MISSING_PARENT"
+  | "DUPLICATE_NODE_ID"
+  | "INVALID_SNAPSHOT"
+  | "CYCLE_DETECTED"
+  | "BROKEN_TOPOLOGY"
+  | "CLOSED_HANDLE";
+
+export class LoomError extends Error {
+  readonly code: LoomErrorCode;
+
+  constructor(code: LoomErrorCode, message: string) {
+    super(message);
+    this.name = "LoomError";
+    this.code = code;
+  }
+}
+
+export function unknownRoot(rootId: string): LoomError {
+  return new LoomError("UNKNOWN_ROOT", `Unknown root: ${rootId}`);
+}
+
+export function missingParent(parentId: string): LoomError {
+  return new LoomError("MISSING_PARENT", `Missing parent node: ${parentId}`);
+}
+
+export function duplicateNodeId(nodeId: string): LoomError {
+  return new LoomError("DUPLICATE_NODE_ID", `Duplicate node ID: ${nodeId}`);
+}
+
+export function invalidSnapshot(message: string): LoomError {
+  return new LoomError("INVALID_SNAPSHOT", message);
+}
+
+export function cycleDetected(nodeId: string): LoomError {
+  return new LoomError("CYCLE_DETECTED", `Cycle detected at node: ${nodeId}`);
+}
+
+export function brokenTopology(message: string): LoomError {
+  return new LoomError("BROKEN_TOPOLOGY", message);
+}
+
+export function closedHandle(): LoomError {
+  return new LoomError("CLOSED_HANDLE", "This loom world handle is closed");
+}

--- a/vendor/loomsync/packages/core/src/index.ts
+++ b/vendor/loomsync/packages/core/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./automerge.js";
+export * from "./browser.js";
+export * from "./errors.js";
+export * from "./links.js";
+export * from "./memory.js";
+export * from "./types.js";

--- a/vendor/loomsync/packages/core/src/json.ts
+++ b/vendor/loomsync/packages/core/src/json.ts
@@ -1,0 +1,13 @@
+export function assertJsonEncodable(value: unknown, label: string): void {
+  try {
+    JSON.stringify(value);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new TypeError(`${label} must be JSON-encodable: ${reason}`);
+  }
+}
+
+export function cloneJson<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/vendor/loomsync/packages/core/src/links.ts
+++ b/vendor/loomsync/packages/core/src/links.ts
@@ -1,0 +1,68 @@
+import type { LoomRootId, LoomWorld, LoomWorlds } from "./types.js";
+
+export interface RootUrlOptions {
+  rootParam?: string;
+  legacyRootParam?: string;
+}
+
+export function getRootIdFromUrl(
+  location: Location | URL,
+  options: RootUrlOptions = {},
+): LoomRootId | null {
+  const rootParam = options.rootParam ?? "story";
+  const legacyRootParam = options.legacyRootParam ?? "root";
+  const params = new URLSearchParams(location.search);
+  const fromQuery = params.get(rootParam) ?? params.get(legacyRootParam);
+  if (fromQuery) return fromQuery;
+
+  const hash = location.hash.replace(/^#/, "");
+  if (!hash) return null;
+  const hashParams = new URLSearchParams(
+    hash.includes("=") ? hash : `${rootParam}=${hash}`,
+  );
+  return hashParams.get(rootParam) ?? hashParams.get(legacyRootParam);
+}
+
+export function createRootShareUrl(
+  rootId: LoomRootId,
+  location: Location | URL,
+  options: RootUrlOptions = {},
+) {
+  const rootParam = options.rootParam ?? "story";
+  const legacyRootParam = options.legacyRootParam ?? "root";
+  const url = new URL(location.href);
+  url.searchParams.delete(legacyRootParam);
+  url.searchParams.set(rootParam, rootId);
+  url.hash = "";
+  return url.toString();
+}
+
+export interface OpenWithRetryOptions {
+  attempts?: number;
+  delayMs?: number;
+}
+
+export async function openRootWithRetry<TPayload, TRootMeta, TNodeMeta>(
+  worlds: LoomWorlds<TPayload, TRootMeta, TNodeMeta>,
+  rootId: LoomRootId,
+  options: OpenWithRetryOptions = {},
+): Promise<LoomWorld<TPayload, TRootMeta, TNodeMeta>> {
+  const attempts = options.attempts ?? 8;
+  const delayMs = options.delayMs ?? 250;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await worlds.openRoot(rootId);
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts - 1) await delay(delayMs);
+    }
+  }
+
+  throw lastError;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/vendor/loomsync/packages/core/src/memory.ts
+++ b/vendor/loomsync/packages/core/src/memory.ts
@@ -1,0 +1,317 @@
+import {
+  brokenTopology,
+  closedHandle,
+  cycleDetected,
+  duplicateNodeId,
+  invalidSnapshot,
+  missingParent,
+  unknownRoot,
+} from "./errors.js";
+import { assertJsonEncodable, cloneJson } from "./json.js";
+import type {
+  LoomNode,
+  LoomNodeId,
+  LoomRoot,
+  LoomRootId,
+  LoomSnapshot,
+  LoomWorld,
+  LoomWorldEvent,
+  LoomWorldListener,
+  LoomWorlds,
+  CreateLoomWorldsOptions,
+  MemoryLoomWorldsOptions,
+} from "./types.js";
+
+const ROOT_CHILDREN_KEY = "__root__";
+
+type InternalDoc<TPayload, TRootMeta, TNodeMeta> = {
+  root: LoomRoot<TRootMeta>;
+  nodes: Map<LoomNodeId, LoomNode<TPayload, TNodeMeta>>;
+  children: Map<string, LoomNodeId[]>;
+  listeners: Set<LoomWorldListener<TPayload, TRootMeta, TNodeMeta>>;
+};
+
+export function createMemoryLoomWorlds<
+  TPayload = unknown,
+  TRootMeta = unknown,
+  TNodeMeta = unknown,
+>(options: MemoryLoomWorldsOptions = {}): LoomWorlds<TPayload, TRootMeta, TNodeMeta> {
+  const createId = options.createId ?? (() => crypto.randomUUID());
+  const now = options.now ?? (() => Date.now());
+  const docs = new Map<LoomRootId, InternalDoc<TPayload, TRootMeta, TNodeMeta>>();
+
+  const createDoc = (meta?: TRootMeta): InternalDoc<TPayload, TRootMeta, TNodeMeta> => {
+    assertJsonEncodable(meta, "root meta");
+    const id = `memory:${createId()}`;
+    const root = omitUndefined({
+      id,
+      meta: cloneJson(meta),
+      createdAt: now(),
+    });
+    return {
+      root,
+      nodes: new Map(),
+      children: new Map([[ROOT_CHILDREN_KEY, []]]),
+      listeners: new Set(),
+    };
+  };
+
+  return {
+    async createRoot(meta) {
+      const doc = createDoc(meta);
+      docs.set(doc.root.id, doc);
+      return cloneJson(doc.root);
+    },
+
+    async getRoot(rootId) {
+      const doc = docs.get(rootId);
+      return doc ? cloneJson(doc.root) : null;
+    },
+
+    async openRoot(rootId) {
+      const doc = docs.get(rootId);
+      if (!doc) throw unknownRoot(rootId);
+      return new MemoryLoomWorld(rootId, doc, createId, now);
+    },
+
+    async importRoot(snapshot) {
+      validateSnapshot(snapshot);
+      const doc = createDoc(snapshot.root.meta);
+      doc.root.createdAt = snapshot.root.createdAt;
+
+      for (const imported of snapshot.nodes) {
+        const node = omitUndefined({
+          ...cloneJson(imported),
+          rootId: doc.root.id,
+        });
+        doc.nodes.set(node.id, node);
+        const parentKey = parentKeyOf(node.parentId);
+        const siblings = doc.children.get(parentKey) ?? [];
+        siblings.push(node.id);
+        doc.children.set(parentKey, siblings);
+        if (!doc.children.has(node.id)) doc.children.set(node.id, []);
+      }
+
+      docs.set(doc.root.id, doc);
+      return cloneJson(doc.root);
+    },
+  };
+}
+
+export function createLoomWorlds<
+  TPayload = unknown,
+  TRootMeta = unknown,
+  TNodeMeta = unknown,
+>(
+  options: CreateLoomWorldsOptions = {},
+): LoomWorlds<TPayload, TRootMeta, TNodeMeta> {
+  if (options.backend && options.backend !== "memory") {
+    throw new Error(`Unsupported LoomSync backend: ${options.backend}`);
+  }
+  return createMemoryLoomWorlds<TPayload, TRootMeta, TNodeMeta>(options);
+}
+
+class MemoryLoomWorld<TPayload, TRootMeta, TNodeMeta>
+  implements LoomWorld<TPayload, TRootMeta, TNodeMeta>
+{
+  private closed = false;
+
+  constructor(
+    readonly id: LoomRootId,
+    private readonly doc: InternalDoc<TPayload, TRootMeta, TNodeMeta>,
+    private readonly createId: () => string,
+    private readonly now: () => number,
+  ) {}
+
+  async root(): Promise<LoomRoot<TRootMeta>> {
+    this.assertOpen();
+    return cloneJson(this.doc.root);
+  }
+
+  async updateRootMeta(meta: TRootMeta): Promise<LoomRoot<TRootMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(meta, "root meta");
+    this.doc.root = omitUndefined({
+      ...this.doc.root,
+      meta: cloneJson(meta),
+    });
+    this.emit({ type: "root-updated", root: cloneJson(this.doc.root) });
+    return cloneJson(this.doc.root);
+  }
+
+  async appendAfter(
+    parentId: LoomNodeId | null,
+    payload: TPayload,
+    meta?: TNodeMeta,
+  ): Promise<LoomNode<TPayload, TNodeMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(payload, "node payload");
+    assertJsonEncodable(meta, "node meta");
+    if (parentId !== null && !this.doc.nodes.has(parentId)) throw missingParent(parentId);
+
+    const nodeId = this.createId();
+    if (nodeId === ROOT_CHILDREN_KEY) throw duplicateNodeId(nodeId);
+    if (this.doc.nodes.has(nodeId)) throw duplicateNodeId(nodeId);
+
+    const node = omitUndefined({
+      id: nodeId,
+      rootId: this.id,
+      parentId,
+      payload: cloneJson(payload),
+      meta: cloneJson(meta),
+      createdAt: this.now(),
+    });
+
+    this.doc.nodes.set(node.id, node);
+    if (!this.doc.children.has(node.id)) this.doc.children.set(node.id, []);
+    const key = parentKeyOf(parentId);
+    const siblings = this.doc.children.get(key) ?? [];
+    siblings.push(node.id);
+    this.doc.children.set(key, siblings);
+
+    const output = cloneJson(node);
+    this.emit({ type: "node-added", rootId: this.id, node: output });
+    return output;
+  }
+
+  async getNode(nodeId: LoomNodeId): Promise<LoomNode<TPayload, TNodeMeta> | null> {
+    this.assertOpen();
+    const node = this.doc.nodes.get(nodeId);
+    return node ? cloneJson(node) : null;
+  }
+
+  async hasNode(nodeId: LoomNodeId): Promise<boolean> {
+    this.assertOpen();
+    return this.doc.nodes.has(nodeId);
+  }
+
+  async childrenOf(parentId: LoomNodeId | null): Promise<LoomNode<TPayload, TNodeMeta>[]> {
+    this.assertOpen();
+    if (parentId !== null && !this.doc.nodes.has(parentId)) throw missingParent(parentId);
+    return (this.doc.children.get(parentKeyOf(parentId)) ?? []).map((id) => {
+      const node = this.doc.nodes.get(id);
+      if (!node) throw brokenTopology(`Child list references missing node: ${id}`);
+      return cloneJson(node);
+    });
+  }
+
+  async pathTo(nodeId: LoomNodeId): Promise<LoomNode<TPayload, TNodeMeta>[]> {
+    this.assertOpen();
+    const path: LoomNode<TPayload, TNodeMeta>[] = [];
+    const seen = new Set<LoomNodeId>();
+    let currentId: LoomNodeId | null = nodeId;
+
+    while (currentId !== null) {
+      if (seen.has(currentId)) throw cycleDetected(currentId);
+      seen.add(currentId);
+
+      const node = this.doc.nodes.get(currentId);
+      if (!node) throw brokenTopology(`Path references missing node: ${currentId}`);
+      path.push(node);
+      currentId = node.parentId;
+    }
+
+    return cloneJson(path.reverse());
+  }
+
+  async leaves(): Promise<LoomNode<TPayload, TNodeMeta>[]> {
+    this.assertOpen();
+    const leaves: LoomNode<TPayload, TNodeMeta>[] = [];
+    const visit = (parentId: LoomNodeId | null) => {
+      const childIds = this.doc.children.get(parentKeyOf(parentId)) ?? [];
+      for (const childId of childIds) {
+        const grandchildren = this.doc.children.get(childId) ?? [];
+        const node = this.doc.nodes.get(childId);
+        if (!node) throw brokenTopology(`Child list references missing node: ${childId}`);
+        if (grandchildren.length === 0) {
+          leaves.push(node);
+        } else {
+          visit(childId);
+        }
+      }
+    };
+    visit(null);
+    return cloneJson(leaves);
+  }
+
+  subscribe(listener: LoomWorldListener<TPayload, TRootMeta, TNodeMeta>): () => void {
+    this.assertOpen();
+    this.doc.listeners.add(listener);
+    return () => {
+      this.doc.listeners.delete(listener);
+    };
+  }
+
+  async export(): Promise<LoomSnapshot<TPayload, TRootMeta, TNodeMeta>> {
+    this.assertOpen();
+    const nodes: LoomNode<TPayload, TNodeMeta>[] = [];
+    const visit = (parentId: LoomNodeId | null) => {
+      for (const childId of this.doc.children.get(parentKeyOf(parentId)) ?? []) {
+        const node = this.doc.nodes.get(childId);
+        if (!node) throw brokenTopology(`Child list references missing node: ${childId}`);
+        nodes.push(node);
+        visit(childId);
+      }
+    };
+    visit(null);
+    return cloneJson({ root: this.doc.root, nodes });
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  private assertOpen() {
+    if (this.closed) throw closedHandle();
+  }
+
+  private emit(event: LoomWorldEvent<TPayload, TRootMeta, TNodeMeta>) {
+    for (const listener of this.doc.listeners) listener(event);
+  }
+}
+
+function validateSnapshot(snapshot: LoomSnapshot<unknown, unknown, unknown>): void {
+  if (!snapshot || typeof snapshot !== "object") throw invalidSnapshot("Snapshot must be an object");
+  if (!snapshot.root || typeof snapshot.root.id !== "string") {
+    throw invalidSnapshot("Snapshot root must include a string id");
+  }
+  if (!Array.isArray(snapshot.nodes)) throw invalidSnapshot("Snapshot nodes must be an array");
+  assertJsonEncodable(snapshot, "snapshot");
+
+  const ids = new Set<LoomNodeId>();
+  for (const node of snapshot.nodes) {
+    if (!node || typeof node.id !== "string") throw invalidSnapshot("Every node needs a string id");
+    if (node.id === ROOT_CHILDREN_KEY) throw invalidSnapshot(`${ROOT_CHILDREN_KEY} is reserved`);
+    if (ids.has(node.id)) throw duplicateNodeId(node.id);
+    if (node.rootId !== snapshot.root.id) {
+      throw invalidSnapshot(`Node ${node.id} belongs to ${node.rootId}, expected ${snapshot.root.id}`);
+    }
+    ids.add(node.id);
+  }
+
+  for (const node of snapshot.nodes) {
+    if (node.parentId !== null && !ids.has(node.parentId)) throw missingParent(node.parentId);
+  }
+
+  for (const node of snapshot.nodes) {
+    const seen = new Set<LoomNodeId>();
+    let current: LoomNodeId | null = node.id;
+    while (current !== null) {
+      if (seen.has(current)) throw cycleDetected(current);
+      seen.add(current);
+      const currentNode = snapshot.nodes.find((candidate) => candidate.id === current);
+      if (!currentNode) throw brokenTopology(`Missing node while validating path: ${current}`);
+      current = currentNode.parentId;
+    }
+  }
+}
+
+function parentKeyOf(parentId: LoomNodeId | null): string {
+  return parentId ?? ROOT_CHILDREN_KEY;
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T;
+}

--- a/vendor/loomsync/packages/core/src/types.ts
+++ b/vendor/loomsync/packages/core/src/types.ts
@@ -1,0 +1,97 @@
+export type LoomRootId = string;
+export type LoomNodeId = string;
+
+export interface LoomRoot<TRootMeta = unknown> {
+  id: LoomRootId;
+  meta?: TRootMeta;
+  createdAt: number;
+}
+
+export interface LoomNode<TPayload = unknown, TNodeMeta = unknown> {
+  id: LoomNodeId;
+  rootId: LoomRootId;
+  parentId: LoomNodeId | null;
+  payload: TPayload;
+  meta?: TNodeMeta;
+  createdAt: number;
+}
+
+export interface LoomSnapshot<
+  TPayload = unknown,
+  TRootMeta = unknown,
+  TNodeMeta = unknown,
+> {
+  root: LoomRoot<TRootMeta>;
+  nodes: LoomNode<TPayload, TNodeMeta>[];
+}
+
+export type LoomWorldEvent<TPayload, TRootMeta, TNodeMeta> =
+  | {
+      type: "node-added";
+      rootId: LoomRootId;
+      node: LoomNode<TPayload, TNodeMeta>;
+    }
+  | {
+      type: "root-updated";
+      root: LoomRoot<TRootMeta>;
+    }
+  | {
+      type: "sync-state";
+      rootId: LoomRootId;
+      online: boolean;
+      syncing: boolean;
+    };
+
+export type LoomWorldListener<TPayload, TRootMeta, TNodeMeta> = (
+  event: LoomWorldEvent<TPayload, TRootMeta, TNodeMeta>,
+) => void;
+
+export interface LoomWorld<
+  TPayload = unknown,
+  TRootMeta = unknown,
+  TNodeMeta = unknown,
+> {
+  id: LoomRootId;
+
+  root(): Promise<LoomRoot<TRootMeta>>;
+  updateRootMeta(meta: TRootMeta): Promise<LoomRoot<TRootMeta>>;
+
+  appendAfter(
+    parentId: LoomNodeId | null,
+    payload: TPayload,
+    meta?: TNodeMeta,
+  ): Promise<LoomNode<TPayload, TNodeMeta>>;
+
+  getNode(nodeId: LoomNodeId): Promise<LoomNode<TPayload, TNodeMeta> | null>;
+  hasNode(nodeId: LoomNodeId): Promise<boolean>;
+
+  childrenOf(parentId: LoomNodeId | null): Promise<LoomNode<TPayload, TNodeMeta>[]>;
+  pathTo(nodeId: LoomNodeId): Promise<LoomNode<TPayload, TNodeMeta>[]>;
+  leaves(): Promise<LoomNode<TPayload, TNodeMeta>[]>;
+
+  subscribe(listener: LoomWorldListener<TPayload, TRootMeta, TNodeMeta>): () => void;
+  export(): Promise<LoomSnapshot<TPayload, TRootMeta, TNodeMeta>>;
+  close(): void;
+}
+
+export interface LoomWorlds<
+  TPayload = unknown,
+  TRootMeta = unknown,
+  TNodeMeta = unknown,
+> {
+  createRoot(meta?: TRootMeta): Promise<LoomRoot<TRootMeta>>;
+  getRoot(rootId: LoomRootId): Promise<LoomRoot<TRootMeta> | null>;
+  openRoot(rootId: LoomRootId): Promise<LoomWorld<TPayload, TRootMeta, TNodeMeta>>;
+  importRoot(
+    snapshot: LoomSnapshot<TPayload, TRootMeta, TNodeMeta>,
+  ): Promise<LoomRoot<TRootMeta>>;
+}
+
+export interface MemoryLoomWorldsOptions {
+  createId?: () => string;
+  now?: () => number;
+}
+
+export interface CreateLoomWorldsOptions extends MemoryLoomWorldsOptions {
+  backend?: "memory";
+}

--- a/vendor/loomsync/packages/core/tsconfig.json
+++ b/vendor/loomsync/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/vendor/loomsync/packages/index/package.json
+++ b/vendor/loomsync/packages/index/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@loomsync/index",
+  "version": "0.1.0",
+  "description": "Index APIs for linked LoomSync roots.",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./automerge": {
+      "types": "./dist/automerge.d.ts",
+      "import": "./dist/automerge.js",
+      "default": "./dist/automerge.js"
+    },
+    "./links": {
+      "types": "./dist/links.d.ts",
+      "import": "./dist/links.js",
+      "default": "./dist/links.js"
+    },
+    "./memory": {
+      "types": "./dist/memory.d.ts",
+      "import": "./dist/memory.js",
+      "default": "./dist/memory.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js",
+      "default": "./dist/types.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@loomsync/core": "workspace:*"
+  }
+}

--- a/vendor/loomsync/packages/index/src/automerge.ts
+++ b/vendor/loomsync/packages/index/src/automerge.ts
@@ -1,0 +1,278 @@
+import { DocHandle, Repo, type AutomergeUrl } from "@automerge/automerge-repo";
+import { LoomError, type LoomRootId } from "../../core/src/index";
+import type {
+  LoomIndex,
+  LoomIndexEntry,
+  LoomIndexEntryInput,
+  LoomIndexEntryPatch,
+  LoomIndexes,
+  LoomIndexEvent,
+  LoomIndexId,
+  LoomIndexInfo,
+  LoomIndexListener,
+  LoomIndexSnapshot,
+} from "./types.js";
+
+type IndexDoc<TEntryMeta, TIndexMeta> = {
+  version: 1;
+  index: LoomIndexInfo<TIndexMeta>;
+  entries: Record<LoomRootId, LoomIndexEntry<TEntryMeta>>;
+  order: LoomRootId[];
+};
+
+export interface AutomergeLoomIndexesOptions {
+  repo?: Repo;
+  now?: () => number;
+}
+
+export function createAutomergeLoomIndexes<
+  TEntryMeta = unknown,
+  TIndexMeta = unknown,
+>(options: AutomergeLoomIndexesOptions = {}): LoomIndexes<TEntryMeta, TIndexMeta> {
+  const repo = options.repo ?? new Repo();
+  const now = options.now ?? (() => Date.now());
+
+  return {
+    async createIndex(meta) {
+      assertJsonEncodable(meta, "index meta");
+      const handle = repo.create<IndexDoc<TEntryMeta, TIndexMeta>>({
+        version: 1,
+        index: {
+          id: "" as LoomIndexId,
+          ...(meta === undefined ? {} : { meta: cloneJson(meta) }),
+          createdAt: now(),
+        },
+        entries: {},
+        order: [],
+      });
+      handle.change((doc) => {
+        doc.index.id = handle.url;
+      });
+      return new AutomergeLoomIndex(handle.url, handle, now);
+    },
+
+    async openIndex(indexId) {
+      let handle: DocHandle<IndexDoc<TEntryMeta, TIndexMeta>>;
+      try {
+        handle = await repo.find<IndexDoc<TEntryMeta, TIndexMeta>>(
+          indexId as AutomergeUrl,
+        );
+        await handle.whenReady();
+      } catch {
+        throw new LoomError("UNKNOWN_ROOT", `Unknown index: ${indexId}`);
+      }
+      return new AutomergeLoomIndex(indexId, handle, now);
+    },
+
+    async importIndex(snapshot) {
+      validateSnapshot(snapshot);
+      const handle = repo.create<IndexDoc<TEntryMeta, TIndexMeta>>({
+        version: 1,
+        index: {
+          id: "" as LoomIndexId,
+          ...(snapshot.index.meta === undefined
+            ? {}
+            : { meta: cloneJson(snapshot.index.meta) }),
+          createdAt: snapshot.index.createdAt,
+        },
+        entries: {},
+        order: [],
+      });
+      handle.change((doc) => {
+        doc.index.id = handle.url;
+        for (const entry of snapshot.entries) {
+          doc.entries[entry.rootId] = cloneJson(entry);
+          doc.order.push(entry.rootId);
+        }
+      });
+      return new AutomergeLoomIndex(handle.url, handle, now);
+    },
+  };
+}
+
+class AutomergeLoomIndex<TEntryMeta, TIndexMeta>
+  implements LoomIndex<TEntryMeta, TIndexMeta>
+{
+  private closed = false;
+  private listeners = new Set<LoomIndexListener<TEntryMeta, TIndexMeta>>();
+  private knownRootIds: Set<LoomRootId>;
+
+  constructor(
+    readonly id: LoomIndexId,
+    private readonly handle: DocHandle<IndexDoc<TEntryMeta, TIndexMeta>>,
+    private readonly now: () => number,
+  ) {
+    this.knownRootIds = new Set(Object.keys(this.handle.doc().entries ?? {}));
+    this.handle.on("change", ({ doc }) => {
+      const current = new Set(Object.keys(doc.entries ?? {}));
+      for (const rootId of current) {
+        if (!this.knownRootIds.has(rootId)) {
+          const entry = doc.entries[rootId];
+          if (entry) this.emit({ type: "entry-added", indexId: this.id, entry: cloneJson(entry) });
+        }
+      }
+      for (const rootId of this.knownRootIds) {
+        if (!current.has(rootId)) this.emit({ type: "entry-removed", indexId: this.id, rootId });
+      }
+      this.knownRootIds = current;
+    });
+  }
+
+  async info(): Promise<LoomIndexInfo<TIndexMeta>> {
+    this.assertOpen();
+    return cloneJson(this.doc().index);
+  }
+
+  async updateInfoMeta(meta: TIndexMeta): Promise<LoomIndexInfo<TIndexMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(meta, "index meta");
+    this.handle.change((doc) => {
+      doc.index.meta = cloneJson(meta) as TIndexMeta;
+    });
+    const index = cloneJson(this.doc().index);
+    this.emit({ type: "index-updated", index });
+    return index;
+  }
+
+  async entries(): Promise<LoomIndexEntry<TEntryMeta>[]> {
+    this.assertOpen();
+    const doc = this.doc();
+    return doc.order.map((rootId) => {
+      const entry = doc.entries[rootId];
+      if (!entry) throw new LoomError("BROKEN_TOPOLOGY", `Index order references missing root: ${rootId}`);
+      return cloneJson(entry);
+    });
+  }
+
+  async get(rootId: LoomRootId): Promise<LoomIndexEntry<TEntryMeta> | null> {
+    this.assertOpen();
+    const entry = this.doc().entries[rootId];
+    return entry ? cloneJson(entry) : null;
+  }
+
+  async has(rootId: LoomRootId): Promise<boolean> {
+    this.assertOpen();
+    return Boolean(this.doc().entries[rootId]);
+  }
+
+  async addRoot(
+    rootId: LoomRootId,
+    input: LoomIndexEntryInput<TEntryMeta> = {},
+  ): Promise<LoomIndexEntry<TEntryMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(input, "index entry");
+    if (this.doc().entries[rootId]) {
+      throw new LoomError("DUPLICATE_NODE_ID", `Index already contains root: ${rootId}`);
+    }
+
+    const entry = omitUndefined({
+      rootId,
+      title: input.title,
+      kind: input.kind,
+      meta: cloneJson(input.meta),
+      addedAt: this.now(),
+      updatedAt: input.updatedAt,
+    }) as LoomIndexEntry<TEntryMeta>;
+
+    this.handle.change((doc) => {
+      doc.entries[rootId] = entry;
+      doc.order.push(rootId);
+    });
+
+    return cloneJson(entry);
+  }
+
+  async updateRoot(
+    rootId: LoomRootId,
+    patch: LoomIndexEntryPatch<TEntryMeta>,
+  ): Promise<LoomIndexEntry<TEntryMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(patch, "index entry patch");
+    const existing = this.doc().entries[rootId];
+    if (!existing) throw new LoomError("UNKNOWN_ROOT", `Index does not contain root: ${rootId}`);
+
+    const updated = omitUndefined({
+      ...existing,
+      ...cloneJson(patch),
+      updatedAt: patch.updatedAt ?? this.now(),
+    }) as LoomIndexEntry<TEntryMeta>;
+    this.handle.change((doc) => {
+      doc.entries[rootId] = updated;
+    });
+    const output = cloneJson(updated);
+    this.emit({ type: "entry-updated", indexId: this.id, entry: output });
+    return output;
+  }
+
+  async removeRoot(rootId: LoomRootId): Promise<void> {
+    this.assertOpen();
+    if (!this.doc().entries[rootId]) return;
+    this.handle.change((doc) => {
+      delete doc.entries[rootId];
+      const index = doc.order.indexOf(rootId);
+      if (index >= 0) doc.order.splice(index, 1);
+    });
+  }
+
+  subscribe(listener: LoomIndexListener<TEntryMeta, TIndexMeta>): () => void {
+    this.assertOpen();
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async export(): Promise<LoomIndexSnapshot<TEntryMeta, TIndexMeta>> {
+    this.assertOpen();
+    return cloneJson({
+      index: this.doc().index,
+      entries: await this.entries(),
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.listeners.clear();
+  }
+
+  private doc() {
+    return this.handle.doc();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new LoomError("CLOSED_HANDLE", "This loom index handle is closed");
+  }
+
+  private emit(event: LoomIndexEvent<TEntryMeta, TIndexMeta>): void {
+    for (const listener of this.listeners) listener(event);
+  }
+}
+
+function validateSnapshot(snapshot: LoomIndexSnapshot<unknown, unknown>): void {
+  assertJsonEncodable(snapshot, "index snapshot");
+  const seen = new Set<LoomRootId>();
+  for (const entry of snapshot.entries) {
+    if (seen.has(entry.rootId)) {
+      throw new LoomError("DUPLICATE_NODE_ID", `Duplicate index root: ${entry.rootId}`);
+    }
+    seen.add(entry.rootId);
+  }
+}
+
+function assertJsonEncodable(value: unknown, label: string): void {
+  try {
+    JSON.stringify(value);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new TypeError(`${label} must be JSON-encodable: ${reason}`);
+  }
+}
+
+function cloneJson<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T;
+}

--- a/vendor/loomsync/packages/index/src/index.ts
+++ b/vendor/loomsync/packages/index/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./automerge.js";
+export * from "./links.js";
+export * from "./memory.js";
+export * from "./types.js";

--- a/vendor/loomsync/packages/index/src/links.ts
+++ b/vendor/loomsync/packages/index/src/links.ts
@@ -1,0 +1,69 @@
+import type { LoomIndex, LoomIndexes } from "./types.js";
+
+export interface IndexUrlOptions {
+  indexParam?: string;
+  legacyIndexParam?: string;
+  rootParams?: string[];
+}
+
+export function getIndexIdFromUrl(
+  location: Location | URL,
+  options: IndexUrlOptions = {},
+): string | null {
+  const indexParam = options.indexParam ?? "index";
+  const legacyIndexParam = options.legacyIndexParam ?? "worlds";
+  const params = new URLSearchParams(location.search);
+  const fromQuery = params.get(indexParam) ?? params.get(legacyIndexParam);
+  if (fromQuery) return fromQuery;
+
+  const hash = location.hash.replace(/^#/, "");
+  if (!hash) return null;
+  const hashParams = new URLSearchParams(hash.includes("=") ? hash : "");
+  return hashParams.get(indexParam) ?? hashParams.get(legacyIndexParam);
+}
+
+export function createIndexShareUrl(
+  indexId: string,
+  location: Location | URL,
+  options: IndexUrlOptions = {},
+) {
+  const indexParam = options.indexParam ?? "index";
+  const legacyIndexParam = options.legacyIndexParam ?? "worlds";
+  const rootParams = options.rootParams ?? ["story", "root"];
+  const url = new URL(location.href);
+  for (const param of rootParams) url.searchParams.delete(param);
+  url.searchParams.delete(legacyIndexParam);
+  url.searchParams.set(indexParam, indexId);
+  url.hash = "";
+  return url.toString();
+}
+
+export interface OpenIndexWithRetryOptions {
+  attempts?: number;
+  delayMs?: number;
+}
+
+export async function openIndexWithRetry<TEntryMeta, TIndexMeta>(
+  indexes: LoomIndexes<TEntryMeta, TIndexMeta>,
+  indexId: string,
+  options: OpenIndexWithRetryOptions = {},
+): Promise<LoomIndex<TEntryMeta, TIndexMeta>> {
+  const attempts = options.attempts ?? 8;
+  const delayMs = options.delayMs ?? 250;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await indexes.openIndex(indexId);
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts - 1) await delay(delayMs);
+    }
+  }
+
+  throw lastError;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/vendor/loomsync/packages/index/src/memory.ts
+++ b/vendor/loomsync/packages/index/src/memory.ts
@@ -1,0 +1,250 @@
+import { LoomError } from "../../core/src/index";
+import type { LoomRootId } from "../../core/src/index";
+import type {
+  LoomIndex,
+  LoomIndexEntry,
+  LoomIndexEntryInput,
+  LoomIndexEntryPatch,
+  LoomIndexes,
+  LoomIndexEvent,
+  LoomIndexId,
+  LoomIndexInfo,
+  LoomIndexListener,
+  LoomIndexSnapshot,
+  CreateLoomIndexesOptions,
+  MemoryLoomIndexesOptions,
+} from "./types.js";
+
+type InternalIndex<TEntryMeta, TIndexMeta> = {
+  info: LoomIndexInfo<TIndexMeta>;
+  entries: Map<LoomRootId, LoomIndexEntry<TEntryMeta>>;
+  order: LoomRootId[];
+  listeners: Set<LoomIndexListener<TEntryMeta, TIndexMeta>>;
+};
+
+export function createMemoryLoomIndexes<
+  TEntryMeta = unknown,
+  TIndexMeta = unknown,
+>(options: MemoryLoomIndexesOptions = {}): LoomIndexes<TEntryMeta, TIndexMeta> {
+  const createId = options.createId ?? (() => crypto.randomUUID());
+  const now = options.now ?? (() => Date.now());
+  const indexes = new Map<LoomIndexId, InternalIndex<TEntryMeta, TIndexMeta>>();
+
+  const createInternal = (meta?: TIndexMeta): InternalIndex<TEntryMeta, TIndexMeta> => {
+    assertJsonEncodable(meta, "index meta");
+    return {
+      info: omitUndefined({
+        id: `memory-index:${createId()}`,
+        meta: cloneJson(meta),
+        createdAt: now(),
+      }),
+      entries: new Map(),
+      order: [],
+      listeners: new Set(),
+    };
+  };
+
+  return {
+    async createIndex(meta) {
+      const index = createInternal(meta);
+      indexes.set(index.info.id, index);
+      return new MemoryLoomIndex(index.info.id, index, now);
+    },
+
+    async openIndex(indexId) {
+      const index = indexes.get(indexId);
+      if (!index) throw new LoomError("UNKNOWN_ROOT", `Unknown index: ${indexId}`);
+      return new MemoryLoomIndex(indexId, index, now);
+    },
+
+    async importIndex(snapshot) {
+      validateSnapshot(snapshot);
+      const index = createInternal(snapshot.index.meta);
+      index.info.createdAt = snapshot.index.createdAt;
+      for (const entry of snapshot.entries) {
+        const cloned = cloneJson(entry);
+        index.entries.set(entry.rootId, cloned);
+        index.order.push(entry.rootId);
+      }
+      indexes.set(index.info.id, index);
+      return new MemoryLoomIndex(index.info.id, index, now);
+    },
+  };
+}
+
+export function createLoomIndexes<TEntryMeta = unknown, TIndexMeta = unknown>(
+  options: CreateLoomIndexesOptions = {},
+): LoomIndexes<TEntryMeta, TIndexMeta> {
+  if (options.backend && options.backend !== "memory") {
+    throw new Error(`Unsupported LoomSync index backend: ${options.backend}`);
+  }
+  return createMemoryLoomIndexes<TEntryMeta, TIndexMeta>(options);
+}
+
+class MemoryLoomIndex<TEntryMeta, TIndexMeta>
+  implements LoomIndex<TEntryMeta, TIndexMeta>
+{
+  private closed = false;
+
+  constructor(
+    readonly id: LoomIndexId,
+    private readonly index: InternalIndex<TEntryMeta, TIndexMeta>,
+    private readonly now: () => number,
+  ) {}
+
+  async info(): Promise<LoomIndexInfo<TIndexMeta>> {
+    this.assertOpen();
+    return cloneJson(this.index.info);
+  }
+
+  async updateInfoMeta(meta: TIndexMeta): Promise<LoomIndexInfo<TIndexMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(meta, "index meta");
+    this.index.info = omitUndefined({ ...this.index.info, meta: cloneJson(meta) });
+    this.emit({ type: "index-updated", index: cloneJson(this.index.info) });
+    return cloneJson(this.index.info);
+  }
+
+  async entries(): Promise<LoomIndexEntry<TEntryMeta>[]> {
+    this.assertOpen();
+    return this.index.order.map((rootId) => {
+      const entry = this.index.entries.get(rootId);
+      if (!entry) throw new LoomError("BROKEN_TOPOLOGY", `Index order references missing root: ${rootId}`);
+      return cloneJson(entry);
+    });
+  }
+
+  async get(rootId: LoomRootId): Promise<LoomIndexEntry<TEntryMeta> | null> {
+    this.assertOpen();
+    const entry = this.index.entries.get(rootId);
+    return entry ? cloneJson(entry) : null;
+  }
+
+  async has(rootId: LoomRootId): Promise<boolean> {
+    this.assertOpen();
+    return this.index.entries.has(rootId);
+  }
+
+  async addRoot(
+    rootId: LoomRootId,
+    input: LoomIndexEntryInput<TEntryMeta> = {},
+  ): Promise<LoomIndexEntry<TEntryMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(input, "index entry");
+    if (this.index.entries.has(rootId)) {
+      throw new LoomError("DUPLICATE_NODE_ID", `Index already contains root: ${rootId}`);
+    }
+
+    const entry = omitUndefined({
+      rootId,
+      title: input.title,
+      kind: input.kind,
+      meta: cloneJson(input.meta),
+      addedAt: this.now(),
+      updatedAt: input.updatedAt,
+    });
+    this.index.entries.set(rootId, entry);
+    this.index.order.push(rootId);
+    const output = cloneJson(entry);
+    this.emit({ type: "entry-added", indexId: this.id, entry: output });
+    return output;
+  }
+
+  async updateRoot(
+    rootId: LoomRootId,
+    patch: LoomIndexEntryPatch<TEntryMeta>,
+  ): Promise<LoomIndexEntry<TEntryMeta>> {
+    this.assertOpen();
+    assertJsonEncodable(patch, "index entry patch");
+    const existing = this.index.entries.get(rootId);
+    if (!existing) throw new LoomError("UNKNOWN_ROOT", `Index does not contain root: ${rootId}`);
+
+    const updated = omitUndefined({
+      ...existing,
+      ...cloneJson(patch),
+      updatedAt: patch.updatedAt ?? this.now(),
+    });
+    this.index.entries.set(rootId, updated);
+    const output = cloneJson(updated);
+    this.emit({ type: "entry-updated", indexId: this.id, entry: output });
+    return output;
+  }
+
+  async removeRoot(rootId: LoomRootId): Promise<void> {
+    this.assertOpen();
+    if (!this.index.entries.has(rootId)) return;
+    this.index.entries.delete(rootId);
+    this.index.order = this.index.order.filter((candidate) => candidate !== rootId);
+    this.emit({ type: "entry-removed", indexId: this.id, rootId });
+  }
+
+  subscribe(listener: LoomIndexListener<TEntryMeta, TIndexMeta>): () => void {
+    this.assertOpen();
+    this.index.listeners.add(listener);
+    return () => this.index.listeners.delete(listener);
+  }
+
+  async export(): Promise<LoomIndexSnapshot<TEntryMeta, TIndexMeta>> {
+    this.assertOpen();
+    return cloneJson({
+      index: this.index.info,
+      entries: await this.entries(),
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new LoomError("CLOSED_HANDLE", "This loom index handle is closed");
+  }
+
+  private emit(event: LoomIndexEvent<TEntryMeta, TIndexMeta>): void {
+    for (const listener of this.index.listeners) listener(event);
+  }
+}
+
+function validateSnapshot(snapshot: LoomIndexSnapshot<unknown, unknown>): void {
+  if (!snapshot || typeof snapshot !== "object") {
+    throw new LoomError("INVALID_SNAPSHOT", "Index snapshot must be an object");
+  }
+  if (!snapshot.index || typeof snapshot.index.id !== "string") {
+    throw new LoomError("INVALID_SNAPSHOT", "Index snapshot needs an index id");
+  }
+  if (!Array.isArray(snapshot.entries)) {
+    throw new LoomError("INVALID_SNAPSHOT", "Index snapshot entries must be an array");
+  }
+  assertJsonEncodable(snapshot, "index snapshot");
+
+  const seen = new Set<LoomRootId>();
+  for (const entry of snapshot.entries) {
+    if (!entry || typeof entry.rootId !== "string") {
+      throw new LoomError("INVALID_SNAPSHOT", "Every index entry needs a rootId");
+    }
+    if (seen.has(entry.rootId)) {
+      throw new LoomError("DUPLICATE_NODE_ID", `Duplicate index root: ${entry.rootId}`);
+    }
+    seen.add(entry.rootId);
+  }
+}
+
+function assertJsonEncodable(value: unknown, label: string): void {
+  try {
+    JSON.stringify(value);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new TypeError(`${label} must be JSON-encodable: ${reason}`);
+  }
+}
+
+function cloneJson<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T;
+}

--- a/vendor/loomsync/packages/index/src/types.ts
+++ b/vendor/loomsync/packages/index/src/types.ts
@@ -1,0 +1,84 @@
+import type { LoomRootId } from "../../core/src/index";
+
+export type LoomIndexId = string;
+
+export interface LoomIndexInfo<TIndexMeta = unknown> {
+  id: LoomIndexId;
+  meta?: TIndexMeta;
+  createdAt: number;
+}
+
+export interface LoomIndexEntry<TEntryMeta = unknown> {
+  rootId: LoomRootId;
+  title?: string;
+  kind?: string;
+  meta?: TEntryMeta;
+  addedAt: number;
+  updatedAt?: number;
+}
+
+export type LoomIndexEntryInput<TEntryMeta = unknown> = Partial<
+  Omit<LoomIndexEntry<TEntryMeta>, "rootId" | "addedAt">
+>;
+
+export type LoomIndexEntryPatch<TEntryMeta = unknown> = Partial<
+  Pick<LoomIndexEntry<TEntryMeta>, "title" | "kind" | "meta" | "updatedAt">
+>;
+
+export interface LoomIndexSnapshot<TEntryMeta = unknown, TIndexMeta = unknown> {
+  index: LoomIndexInfo<TIndexMeta>;
+  entries: LoomIndexEntry<TEntryMeta>[];
+}
+
+export type LoomIndexEvent<TEntryMeta, TIndexMeta> =
+  | { type: "entry-added"; indexId: LoomIndexId; entry: LoomIndexEntry<TEntryMeta> }
+  | { type: "entry-updated"; indexId: LoomIndexId; entry: LoomIndexEntry<TEntryMeta> }
+  | { type: "entry-removed"; indexId: LoomIndexId; rootId: LoomRootId }
+  | { type: "index-updated"; index: LoomIndexInfo<TIndexMeta> }
+  | { type: "sync-state"; indexId: LoomIndexId; online: boolean; syncing: boolean };
+
+export type LoomIndexListener<TEntryMeta, TIndexMeta> = (
+  event: LoomIndexEvent<TEntryMeta, TIndexMeta>,
+) => void;
+
+export interface LoomIndex<TEntryMeta = unknown, TIndexMeta = unknown> {
+  id: LoomIndexId;
+
+  info(): Promise<LoomIndexInfo<TIndexMeta>>;
+  updateInfoMeta(meta: TIndexMeta): Promise<LoomIndexInfo<TIndexMeta>>;
+
+  entries(): Promise<LoomIndexEntry<TEntryMeta>[]>;
+  get(rootId: LoomRootId): Promise<LoomIndexEntry<TEntryMeta> | null>;
+  has(rootId: LoomRootId): Promise<boolean>;
+
+  addRoot(
+    rootId: LoomRootId,
+    entry?: LoomIndexEntryInput<TEntryMeta>,
+  ): Promise<LoomIndexEntry<TEntryMeta>>;
+  updateRoot(
+    rootId: LoomRootId,
+    patch: LoomIndexEntryPatch<TEntryMeta>,
+  ): Promise<LoomIndexEntry<TEntryMeta>>;
+  removeRoot(rootId: LoomRootId): Promise<void>;
+
+  subscribe(listener: LoomIndexListener<TEntryMeta, TIndexMeta>): () => void;
+  export(): Promise<LoomIndexSnapshot<TEntryMeta, TIndexMeta>>;
+  close(): void;
+}
+
+export interface LoomIndexes<TEntryMeta = unknown, TIndexMeta = unknown> {
+  createIndex(meta?: TIndexMeta): Promise<LoomIndex<TEntryMeta, TIndexMeta>>;
+  openIndex(indexId: LoomIndexId): Promise<LoomIndex<TEntryMeta, TIndexMeta>>;
+  importIndex(
+    snapshot: LoomIndexSnapshot<TEntryMeta, TIndexMeta>,
+  ): Promise<LoomIndex<TEntryMeta, TIndexMeta>>;
+}
+
+export interface MemoryLoomIndexesOptions {
+  createId?: () => string;
+  now?: () => number;
+}
+
+export interface CreateLoomIndexesOptions extends MemoryLoomIndexesOptions {
+  backend?: "memory";
+}

--- a/vendor/loomsync/packages/index/tsconfig.json
+++ b/vendor/loomsync/packages/index/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/vendor/loomsync/packages/sync-server/package.json
+++ b/vendor/loomsync/packages/sync-server/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@loomsync/sync-server",
+  "version": "0.1.0",
+  "description": "Automerge WebSocket sync relay for LoomSync.",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@automerge/automerge-repo": "^2.5.5",
+    "@automerge/automerge-repo-network-websocket": "^2.5.5",
+    "isomorphic-ws": "^5.0.0"
+  }
+}

--- a/vendor/loomsync/packages/sync-server/src/index.ts
+++ b/vendor/loomsync/packages/sync-server/src/index.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs/promises";
+import type http from "node:http";
+import path from "node:path";
+import { Repo, type RepoConfig } from "@automerge/automerge-repo";
+import type {
+  Chunk,
+  StorageAdapterInterface,
+  StorageKey,
+} from "@automerge/automerge-repo";
+import { WebSocketServerAdapter } from "@automerge/automerge-repo-network-websocket";
+import { WebSocketServer } from "isomorphic-ws";
+
+export interface LoomSyncServerOptions {
+  port?: number;
+  host?: string;
+  path?: string;
+  storageDir?: string;
+  keepAliveInterval?: number;
+  repoConfig?: Omit<RepoConfig, "network">;
+}
+
+export interface LoomSyncServer {
+  repo: Repo;
+  server: WebSocketServer;
+  url: string;
+  close(): Promise<void>;
+}
+
+export function createLoomSyncServer(options: LoomSyncServerOptions = {}): LoomSyncServer {
+  const port = options.port ?? 0;
+  const host = options.host ?? "127.0.0.1";
+  const server = new WebSocketServer({
+    host,
+    port,
+    path: options.path,
+  });
+  const repo = createRelayRepo(server, options);
+
+  return {
+    repo,
+    server,
+    get url() {
+      const address = server.address();
+      if (typeof address === "string" || address === null) return `ws://${host}:${port}`;
+      return `ws://${address.address}:${address.port}`;
+    },
+    async close() {
+      await repo.shutdown();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error?: Error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+export interface AttachLoomSyncServerOptions extends Omit<LoomSyncServerOptions, "port" | "host"> {
+  repo?: Repo;
+}
+
+export function attachLoomSyncServer(
+  server: http.Server,
+  options: AttachLoomSyncServerOptions = {},
+) {
+  const socketServer = new WebSocketServer({
+    server,
+    path: options.path ?? "/loomsync",
+  });
+  const repo = options.repo ?? createRelayRepo(socketServer, options);
+
+  server.on("close", () => {
+    socketServer.close();
+  });
+
+  return {
+    repo,
+    server: socketServer,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        socketServer.close((error?: Error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
+
+function createRelayRepo(
+  server: WebSocketServer,
+  options: Pick<LoomSyncServerOptions, "keepAliveInterval" | "repoConfig" | "storageDir">,
+) {
+  const adapter = new WebSocketServerAdapter(server, options.keepAliveInterval);
+  return new Repo({
+    storage: options.storageDir
+      ? new FileStorageAdapter(options.storageDir)
+      : options.repoConfig?.storage,
+    ...options.repoConfig,
+    network: [adapter],
+  });
+}
+
+export class FileStorageAdapter implements StorageAdapterInterface {
+  constructor(private readonly dir: string) {}
+
+  async load(key: StorageKey): Promise<Uint8Array | undefined> {
+    try {
+      return toUint8Array(await fs.readFile(this.filePath(key)));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  async save(key: StorageKey, data: Uint8Array): Promise<void> {
+    await fs.mkdir(this.dir, { recursive: true });
+    await fs.writeFile(this.filePath(key), data);
+  }
+
+  async remove(key: StorageKey): Promise<void> {
+    try {
+      await fs.unlink(this.filePath(key));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+
+  async loadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
+    await fs.mkdir(this.dir, { recursive: true });
+    const prefix = this.keyToFilename(keyPrefix);
+    const files = await fs.readdir(this.dir);
+    return Promise.all(
+      files
+        .filter((file) => this.matchesPrefix(file, prefix))
+        .map(async (file) => ({
+          key: this.filenameToKey(file),
+          data: toUint8Array(await fs.readFile(path.join(this.dir, file))),
+        })),
+    );
+  }
+
+  async removeRange(keyPrefix: StorageKey): Promise<void> {
+    await fs.mkdir(this.dir, { recursive: true });
+    const prefix = this.keyToFilename(keyPrefix);
+    const files = await fs.readdir(this.dir);
+    await Promise.all(
+      files
+        .filter((file) => this.matchesPrefix(file, prefix))
+        .map((file) => fs.unlink(path.join(this.dir, file))),
+    );
+  }
+
+  private filePath(key: StorageKey) {
+    return path.join(this.dir, this.keyToFilename(key));
+  }
+
+  private keyToFilename(key: StorageKey) {
+    return key.map((part) => encodeURIComponent(part)).join(".");
+  }
+
+  private filenameToKey(filename: string): StorageKey {
+    return filename.split(".").map((part) => decodeURIComponent(part));
+  }
+
+  private matchesPrefix(filename: string, prefix: string) {
+    return !prefix || filename === prefix || filename.startsWith(`${prefix}.`);
+  }
+}
+
+function toUint8Array(data: Uint8Array) {
+  return new Uint8Array(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength));
+}

--- a/vendor/loomsync/packages/sync-server/tsconfig.json
+++ b/vendor/loomsync/packages/sync-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/vendor/loomsync/packages/text/package.json
+++ b/vendor/loomsync/packages/text/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@loomsync/text",
+  "version": "0.1.0",
+  "description": "Text helpers for LoomSync branching worlds.",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./text": {
+      "types": "./dist/text.d.ts",
+      "import": "./dist/text.js",
+      "default": "./dist/text.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js",
+      "default": "./dist/types.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@loomsync/core": "workspace:*"
+  }
+}

--- a/vendor/loomsync/packages/text/src/index.ts
+++ b/vendor/loomsync/packages/text/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./text.js";
+export * from "./types.js";

--- a/vendor/loomsync/packages/text/src/text.ts
+++ b/vendor/loomsync/packages/text/src/text.ts
@@ -1,0 +1,62 @@
+import type {
+  LoomNode,
+  LoomNodeId,
+  LoomRoot,
+  LoomSnapshot,
+  LoomWorld,
+} from "../../core/src/index";
+import type { StoryNode, StoryPathNode, TextPayload } from "./types.js";
+
+export function flattenPath(nodes: LoomNode<TextPayload>[]): string {
+  return nodes.map((node) => node.payload.text).join("");
+}
+
+export function pathToStoryNodes(nodes: LoomNode<TextPayload>[]): StoryPathNode[] {
+  return nodes.map((node) => ({
+    id: node.id,
+    text: node.payload.text,
+  }));
+}
+
+export async function appendChain<TNodeMeta = unknown>(
+  world: LoomWorld<TextPayload, unknown, TNodeMeta>,
+  parentId: LoomNodeId | null,
+  chunks: TextPayload[],
+  meta?: TNodeMeta,
+): Promise<LoomNode<TextPayload, TNodeMeta>[]> {
+  const appended: LoomNode<TextPayload, TNodeMeta>[] = [];
+  let currentParent = parentId;
+  for (const chunk of chunks) {
+    const node = await world.appendAfter(currentParent, chunk, meta);
+    appended.push(node);
+    currentParent = node.id;
+  }
+  return appended;
+}
+
+export function snapshotFromNestedStory<TRootMeta = unknown>(
+  tree: { root: StoryNode },
+  root: LoomRoot<TRootMeta>,
+): LoomSnapshot<TextPayload, TRootMeta> {
+  const nodes: LoomNode<TextPayload>[] = [];
+
+  const visit = (node: StoryNode, parentId: LoomNodeId | null) => {
+    nodes.push({
+      id: node.id,
+      rootId: root.id,
+      parentId,
+      payload: { text: node.text },
+      createdAt: root.createdAt,
+    });
+
+    for (const child of node.continuations ?? []) {
+      visit(child, node.id);
+    }
+  };
+
+  for (const child of tree.root.continuations ?? []) {
+    visit(child, null);
+  }
+
+  return { root, nodes };
+}

--- a/vendor/loomsync/packages/text/src/types.ts
+++ b/vendor/loomsync/packages/text/src/types.ts
@@ -1,0 +1,15 @@
+import type { LoomNodeId } from "../../core/src/index";
+
+export type TextPayload = { text: string };
+
+export interface StoryNode {
+  id: string;
+  text: string;
+  continuations?: StoryNode[];
+  lastSelectedIndex?: number;
+}
+
+export interface StoryPathNode {
+  id: LoomNodeId;
+  text: string;
+}

--- a/vendor/loomsync/packages/text/tsconfig.json
+++ b/vendor/loomsync/packages/text/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/vendor/loomsync/pnpm-lock.yaml
+++ b/vendor/loomsync/pnpm-lock.yaml
@@ -1,0 +1,1272 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@automerge/automerge-repo':
+        specifier: ^2.5.5
+        version: 2.5.5
+      '@automerge/automerge-repo-network-broadcastchannel':
+        specifier: ^2.5.5
+        version: 2.5.5
+      '@automerge/automerge-repo-network-websocket':
+        specifier: ^2.5.5
+        version: 2.5.5
+      '@automerge/automerge-repo-storage-indexeddb':
+        specifier: ^2.5.5
+        version: 2.5.5
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      isomorphic-ws:
+        specifier: ^5.0.0
+        version: 5.0.0(ws@8.20.0)
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@22.19.17)
+
+  packages/core: {}
+
+  packages/index:
+    dependencies:
+      '@loomsync/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/text:
+    dependencies:
+      '@loomsync/core':
+        specifier: workspace:*
+        version: link:../core
+
+packages:
+
+  '@automerge/automerge-repo-network-broadcastchannel@2.5.5':
+    resolution: {integrity: sha512-yYSW2lEd+aJyY6HRS2Q0PCWUmtWiGhp8oRdmL61KipRC31dZaYo+qsRVt+xw45MAC0ZBWUYHuvF6xqCPDB4Q1A==}
+
+  '@automerge/automerge-repo-network-websocket@2.5.5':
+    resolution: {integrity: sha512-pwHNXTsTTfofU3X/wtFa9L3lWfAJBI7v1+3EKgFDgEodUJo9FPDH0hcy4HUsQiDrQPADO7FP9fVOQSXVm8n5VA==}
+
+  '@automerge/automerge-repo-storage-indexeddb@2.5.5':
+    resolution: {integrity: sha512-pH8tw8uLqEtv1POhy2IFnpBDFpGqiR6YM3w4Rk0NkmerstUxQwrqkkeABlkvF5Al6krlu6dC47LnF8v5cHB3Fg==}
+
+  '@automerge/automerge-repo@2.5.5':
+    resolution: {integrity: sha512-A7vrMvIx5axW3smczZStONaZsksFSjKK8e0Th0u+oEV3aMsylaExpDvjRE2ZIZotJT30+l3tCUlge/n/XGK25Q==}
+
+  '@automerge/automerge@3.2.6':
+    resolution: {integrity: sha512-9/GXXfYYWNVGpnbRrGQzTNU4fWZ3XaEMeEg0OrpK4pvlQSpkmUBoirEb/4TMK6BwMysZGV5Yeneq3wwc7RNGfg==}
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    resolution: {integrity: sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    resolution: {integrity: sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    resolution: {integrity: sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    resolution: {integrity: sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    resolution: {integrity: sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  base-x@4.0.1:
+    resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
+
+  bs58@5.0.0:
+    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
+
+  bs58check@3.0.1:
+    resolution: {integrity: sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  cbor-extract@2.2.2:
+    resolution: {integrity: sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==}
+    hasBin: true
+
+  cbor-x@1.6.4:
+    resolution: {integrity: sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-gyp-build-optional-packages@5.1.1:
+    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
+    hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xstate@5.30.0:
+    resolution: {integrity: sha512-mIzIuMjtYVkqXq9dUzYQoag7b/dF1CBS/yhliuPLfR0FwKPC18HiUivb/crcqY2gknhR8gJEhnppLg6ubQ0gGw==}
+
+snapshots:
+
+  '@automerge/automerge-repo-network-broadcastchannel@2.5.5':
+    dependencies:
+      '@automerge/automerge-repo': 2.5.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@automerge/automerge-repo-network-websocket@2.5.5':
+    dependencies:
+      '@automerge/automerge-repo': 2.5.5
+      cbor-x: 1.6.4
+      debug: 4.4.3
+      eventemitter3: 5.0.4
+      isomorphic-ws: 5.0.0(ws@8.20.0)
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@automerge/automerge-repo-storage-indexeddb@2.5.5':
+    dependencies:
+      '@automerge/automerge-repo': 2.5.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@automerge/automerge-repo@2.5.5':
+    dependencies:
+      '@automerge/automerge': 3.2.6
+      bs58check: 3.0.1
+      cbor-x: 1.6.4
+      debug: 4.4.3
+      eventemitter3: 5.0.4
+      fast-sha256: 1.3.0
+      uuid: 9.0.1
+      xstate: 5.30.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@automerge/automerge@3.2.6': {}
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@noble/hashes@1.8.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  base-x@4.0.1: {}
+
+  bs58@5.0.0:
+    dependencies:
+      base-x: 4.0.1
+
+  bs58check@3.0.1:
+    dependencies:
+      '@noble/hashes': 1.8.0
+      bs58: 5.0.0
+
+  cac@6.7.14: {}
+
+  cbor-extract@2.2.2:
+    dependencies:
+      node-gyp-build-optional-packages: 5.1.1
+    optionalDependencies:
+      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-darwin-x64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-x64': 2.2.2
+      '@cbor-extract/cbor-extract-win32-x64': 2.2.2
+    optional: true
+
+  cbor-x@1.6.4:
+    optionalDependencies:
+      cbor-extract: 2.2.2
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
+
+  fast-sha256@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  isomorphic-ws@5.0.0(ws@8.20.0):
+    dependencies:
+      ws: 8.20.0
+
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  node-gyp-build-optional-packages@5.1.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  uuid@14.0.0: {}
+
+  uuid@9.0.1: {}
+
+  vite-node@3.2.4(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.17):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@22.19.17)
+      vite-node: 3.2.4(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.20.0: {}
+
+  xstate@5.30.0: {}

--- a/vendor/loomsync/pnpm-workspace.yaml
+++ b/vendor/loomsync/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/vendor/loomsync/tsconfig.base.json
+++ b/vendor/loomsync/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  }
+}

--- a/vendor/loomsync/vitest.config.ts
+++ b/vendor/loomsync/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@loomsync/core": new URL("./packages/core/src/index.ts", import.meta.url).pathname,
+      "@loomsync/index": new URL("./packages/index/src/index.ts", import.meta.url).pathname,
+      "@loomsync/text": new URL("./packages/text/src/index.ts", import.meta.url).pathname,
+    },
+  },
+  test: {
+    include: ["packages/*/test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

This is a clean V2-first LoomSync cutover branch from `main`, not a replay of the earlier experimental integration branch.

- vendors the current LoomSync library into `vendor/loomsync`
- attaches the LoomSync WebSocket relay at `/loomsync`
- stores story worlds as Automerge-backed LoomSync roots
- stores the story index as a separate LoomSync index document
- supports `?story=<rootId>` and `?index=<indexId>` share links
- keeps preferred branch traversal in session state, outside shared world data
- converts edits into append-only revision branches instead of mutating historical nodes
- persists generated continuations through LoomSync, including auto-mode continuations
- adds unit and Playwright coverage for story sync, persistence, and sharing

## Verification

- `bun run lint`
- `bun test`
- `bun run build`
- `bun run test:e2e`
- dev-server Playwright smoke against `http://127.0.0.1:5173/`:
  - open two tabs in one browser context
  - generate with mocked `/api/generate`
  - verify the second tab updates without reload
  - open `?story=<rootId>` in another browser context
  - open `?index=<indexId>` in another browser context

## Notes

The e2e test uses mocked generation and judging routes, so no OpenRouter key is required.
