### PR TITLE
fix: allow unauthenticated Lync sync connections

### DIFF
--- a/server/lync.ts
+++ b/server/lync.ts
@@ -1,7 +1,6 @@
 import type http from "http";
 import path from "path";
 import { attachLyncServer as attachVendoredLyncServer } from "../vendor/lync/packages/sync-server/src/index";
-import { hasSiteAccess } from "./siteAuth";
 
 let attached = false;
 
@@ -10,7 +9,6 @@ export function attachLyncServer(server: http.Server) {
   attached = true;
   attachVendoredLyncServer(server, {
     path: "/lync",
-    authenticate: (request) => hasSiteAccess(request),
     storageDir:
       process.env.LYNC_STORAGE_DIR ??
       path.resolve(process.cwd(), ".data/lync"),


### PR DESCRIPTION
## Summary

- Remove the `authenticate` callback from the Lync sync server options in `server/lync.ts`
- Remove the now-unused `hasSiteAccess` import
- The `/lync` endpoint only exchanges Automerge CRDT documents and doesn't expose generation APIs or server resources, so site auth is unnecessary here
- This unblocks headless clients (like story-machine) from syncing looms

## Test plan

- [ ] Verify the textile server starts without errors
- [ ] Confirm headless clients can connect to `/lync` and sync Automerge documents
- [ ] Confirm authenticated features (generation APIs, etc.) remain gated behind site auth