### PR TITLE
fix: skip site auth for /lync WebSocket upgrades

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -44,10 +44,9 @@ export async function createServer() {
   configureTrustedProxies(app);
   setupSiteAuthRoutes(app);
   app.use((req, res, next) => {
-    // Lync sync uses raw WebSocket upgrades on the http_server — Express
-    // middleware shouldn't block the initial HTTP request that triggers
-    // the upgrade.  Let it through; the sync-server handles its own auth.
-    if (req.path.startsWith("/lync")) return next();
+    // Lync sync uses raw WebSocket upgrades on the http_server.
+    // Only skip auth for actual upgrade requests on the exact path.
+    if (req.path === "/lync" && req.headers.upgrade === "websocket") return next();
     return requireSiteAccess(req, res, next);
   });
 

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -43,7 +43,13 @@ export async function createServer() {
   const app = express();
   configureTrustedProxies(app);
   setupSiteAuthRoutes(app);
-  app.use(requireSiteAccess);
+  app.use((req, res, next) => {
+    // Lync sync uses raw WebSocket upgrades on the http_server — Express
+    // middleware shouldn't block the initial HTTP request that triggers
+    // the upgrade.  Let it through; the sync-server handles its own auth.
+    if (req.path.startsWith("/lync")) return next();
+    return requireSiteAccess(req, res, next);
+  });
 
   const http_server = http.createServer(app);
   attachLyncServer(http_server);


### PR DESCRIPTION
## Summary

- The global `requireSiteAccess` middleware was returning 302 on WebSocket upgrade requests to `/lync`, blocking headless clients from syncing Automerge documents
- Skip `/lync` in the middleware — the sync server handles its own concerns
- API routes keep their own `requireApiAuth`, all other paths still require site access

Follow-up to #51. That PR removed the `authenticate` callback inside the Lync server config, but the Express middleware was catching the request first.