### PR TITLE
[codex] Reuse app styling on login gate

### DIFF
--- a/server/__tests__/siteAuth.test.ts
+++ b/server/__tests__/siteAuth.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "bun:test";
+import express from "express";
+import http from "http";
 import {
   createSiteAuthCookieValue,
   hasSiteAccess,
   hasValidSiteSession,
   isSiteAuthConfigured,
+  setupSiteAuthRoutes,
   SITE_AUTH_COOKIE,
 } from "../siteAuth";
 
@@ -77,5 +80,35 @@ describe("site auth", () => {
         "script-secret",
       ),
     ).toBe(true);
+  });
+
+  it("serves login styles without Tailwind source directives", async () => {
+    const app = express();
+    setupSiteAuthRoutes(app);
+    const server = http.createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Expected TCP test server address");
+    }
+
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/_textile/terminal.css`,
+      );
+      const css = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/css");
+      expect(css).toContain(".terminal-screen");
+      expect(css).toContain(".gamepad-btn");
+      expect(css).toContain("/_textile/fonts/Iosevka-Regular.woff2");
+      expect(css).not.toContain('@import "tailwindcss"');
+      expect(css).not.toContain("@theme");
+      expect(css).not.toContain("@source");
+    } finally {
+      server.close();
+    }
   });
 });

--- a/server/siteAuth.ts
+++ b/server/siteAuth.ts
@@ -1,11 +1,19 @@
 import crypto from "crypto";
 import type { Application, NextFunction, Request, Response } from "express";
 import express from "express";
+import fs from "fs";
+import path from "path";
 import { hasValidApiAuthToken } from "./apiAuthToken";
 import { config } from "./config";
 import { createRateLimitMiddleware } from "./rateLimit";
 
 export const SITE_AUTH_COOKIE = "textile_site";
+const LOGIN_STYLES_PATH = "/_textile/terminal.css";
+const LOGIN_FONT_PATH = "/_textile/fonts";
+const LOGIN_FONT_FILES = new Set([
+  "Iosevka-Regular.woff2",
+  "IosevkaSlab-Regular.woff2",
+]);
 
 type HeaderRequest = {
   headers: Record<string, string | string[] | undefined> & {
@@ -103,175 +111,255 @@ function escapeAttribute(value: string) {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
 }
 
+function rewriteLoginFontUrls(css: string) {
+  return css.replace(
+    /url\((["']?)(?:\.\.\/assets\/fonts\/|\/assets\/)(Iosevka(?:Slab)?-Regular\.woff2)\1\)/g,
+    (_match, _quote, file: string) => `url("${LOGIN_FONT_PATH}/${file}")`,
+  );
+}
+
+function loadLoginStylesheet() {
+  const builtCssPath = path.resolve(
+    process.cwd(),
+    "dist/client/assets/index.css",
+  );
+  if (!config.isDevelopment && fs.existsSync(builtCssPath)) {
+    return rewriteLoginFontUrls(fs.readFileSync(builtCssPath, "utf-8"));
+  }
+
+  const sourceCssPath = path.resolve(process.cwd(), "client/styles/terminal.css");
+  const sourceCss = fs.readFileSync(sourceCssPath, "utf-8");
+
+  return rewriteLoginFontUrls(
+    sourceCss
+      .replace(/@import\s+"tailwindcss";\s*/g, "")
+      .replace(/@theme\s*\{[\s\S]*?\}\s*/g, "")
+      .replace(/@source\s+[^;]+;\s*/g, ""),
+  );
+}
+
+const themeBootstrapScript = `(() => {
+  const LIGHT_THEMES = {
+    "theme-light": 1,
+    "theme-blue": 1,
+    "theme-aperture": 1,
+  };
+  const DARK_THEMES = {
+    "theme-black-green": 1,
+    "theme-nerv": 1,
+    "theme-outrun": 1,
+  };
+  const DEFAULT_LIGHT = "theme-light";
+  const DEFAULT_DARK = "theme-black-green";
+  const pickLight = (id) => (id && LIGHT_THEMES[id] ? id : DEFAULT_LIGHT);
+  const pickDark = (id) => (id && DARK_THEMES[id] ? id : DEFAULT_DARK);
+
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  let themeClass = prefersDark ? DEFAULT_DARK : DEFAULT_LIGHT;
+  try {
+    const raw = localStorage.getItem("textile-theme-preferences");
+    if (raw) {
+      const prefs = JSON.parse(raw);
+      const mode = prefs && prefs.mode;
+      if (mode === "light") {
+        themeClass = pickLight(prefs.paletteLight);
+      } else if (mode === "dark") {
+        themeClass = pickDark(prefs.paletteDark);
+      } else {
+        themeClass = prefersDark
+          ? pickDark(prefs.paletteDark)
+          : pickLight(prefs.paletteLight);
+      }
+    } else {
+      const legacy = localStorage.getItem("theme");
+      if (legacy === "phosphor") themeClass = DEFAULT_DARK;
+      else if (legacy === "light") themeClass = DEFAULT_LIGHT;
+    }
+    const font = localStorage.getItem("textile-font") || "iosevka";
+    const fontClass = font === "iosevka-slab"
+      ? "font-use-iosevka-slab"
+      : "font-use-iosevka";
+    document.documentElement.classList.add(themeClass, fontClass);
+  } catch (_) {
+    document.documentElement.classList.add(
+      prefersDark ? DEFAULT_DARK : DEFAULT_LIGHT,
+      "font-use-iosevka",
+    );
+  }
+})();`;
+
 function loginPage(next = "/", error = false) {
   const message = error
-    ? "<p class=\"error\" role=\"alert\">That password did not work.</p>"
+    ? "<p class=\"login-error\" role=\"alert\">That password did not work.</p>"
     : "";
   const safeNext = escapeAttribute(safeRedirectTarget(next));
   return `<!doctype html>
-	<html lang="en">
-	  <head>
-    <meta charset="utf-8" />
-	    <meta name="viewport" content="width=device-width, initial-scale=1" />
-	    <title>Textile</title>
-	    <style>
-	      :root {
-	        --theme-background: #000;
-	        --theme-background-modal: #262626;
-	        --theme-background-input: #525252;
-	        --theme-border: #393939;
-	        --theme-border-subdued: rgba(82, 82, 82, 0.3);
-	        --theme-text: #24a148;
-	        --theme-button: #24a148;
-	        --theme-button-text: #044317;
-	        --theme-focused-foreground: #c6c6c6;
-	        --theme-muted: #6fdc8c;
-	        --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	      }
-	      * {
-	        box-sizing: border-box;
-	      }
-	      body {
-	        margin: 0;
-	        min-height: 100dvh;
-	        display: flex;
-	        align-items: center;
-	        justify-content: center;
-	        padding: 1rem;
-	        background: var(--theme-background);
-	        color: var(--theme-text);
-	        font-family: var(--font-family-mono);
-	      }
-	      main {
-	        width: min(90vw, 32rem);
-	        min-width: min(20rem, calc(100vw - 2rem));
-	      }
-	      .screen {
-	        width: 100%;
-	        border: 2px solid var(--theme-text);
-	        background: var(--theme-background);
-	        box-shadow: 0 0 0 1px var(--theme-border-subdued);
-	      }
-	      .mode-bar {
-	        display: flex;
-	        align-items: center;
-	        justify-content: space-between;
-	        gap: 1.5ch;
-	        min-width: 0;
-	        padding: 0.75ch 1.25ch;
-	        border-bottom: 1px solid var(--theme-border);
-	      }
-	      .mode-bar-title {
-	        font-weight: 700;
-	        white-space: nowrap;
-	      }
-	      .mode-bar-status {
-	        min-width: 0;
-	        overflow: hidden;
-	        color: var(--theme-muted);
-	        text-overflow: ellipsis;
-	        white-space: nowrap;
-	      }
-	      .content {
-	        padding: 1rem;
-	        line-height: 1.6;
-	      }
-	      h1 {
-	        margin: 0 0 1rem;
-	        color: var(--theme-focused-foreground);
-	        font-size: 1.25rem;
-	        font-weight: 700;
-	      }
-	      form {
-	        display: grid;
-	        gap: 0.75rem;
-	      }
-	      label {
-	        color: var(--theme-muted);
-	      }
-	      input,
-	      button {
-	        width: 100%;
-	        min-height: 3rem;
-	        border: 2px solid var(--theme-text);
-	        border-radius: 0;
-	        font: inherit;
-	      }
-	      input {
-	        padding: 0.75rem;
-	        background: var(--theme-background-input);
-	        color: var(--theme-focused-foreground);
-	      }
-	      input:focus {
-	        border-color: var(--theme-focused-foreground);
-	        outline: none;
-	        box-shadow: 0 0 0 2px var(--theme-border);
-	      }
-	      button {
-	        display: flex;
-	        align-items: center;
-	        justify-content: center;
-	        background: transparent;
-	        color: var(--theme-text);
-	        cursor: pointer;
-	        user-select: none;
-	        transition: background-color 0.1s ease, border-color 0.1s ease, color 0.1s ease;
-	      }
-	      button:hover,
-	      button:focus-visible {
-	        border-color: var(--theme-focused-foreground);
-	        color: var(--theme-focused-foreground);
-	        outline: none;
-	      }
-	      button:active {
-	        background: var(--theme-focused-foreground);
-	        color: var(--theme-background);
-	        border-color: var(--theme-focused-foreground);
-	      }
-	      .error {
-	        margin: 0 0 1rem;
-	        padding: 0.75rem;
-	        border: 1px solid #c83232;
-	        color: #ff9632;
-	      }
-	      @media (max-width: 22rem) {
-	        body {
-	          padding: 0.75rem;
-	        }
-	        main {
-	          min-width: 0;
-	          width: 100%;
-	        }
-	        .content {
-	          padding: 0.75rem;
-	        }
-	      }
-	    </style>
-	  </head>
-	  <body>
-	    <main>
-	      <section class="screen" aria-labelledby="title">
-	        <div class="mode-bar">
-	          <span class="mode-bar-title">Textile</span>
-	          <span class="mode-bar-status">private alpha</span>
-	        </div>
-	        <div class="content">
-	          <h1 id="title">Enter password</h1>
-	          ${message}
-	          <form method="post" action="/_textile/login">
-	            <input type="hidden" name="next" value="${safeNext}" />
-	            <label for="password">Password</label>
-	            <input id="password" name="password" type="password" autocomplete="current-password" autofocus />
-	            <button type="submit">Enter</button>
-	          </form>
-	        </div>
-	      </section>
-	    </main>
-	  </body>
-	</html>`;
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="theme-color" content="#2a2a2a" />
+      <title>Textile</title>
+      <script>${themeBootstrapScript}</script>
+      <link rel="stylesheet" href="${LOGIN_STYLES_PATH}" />
+      <style>
+        .login-main {
+          justify-content: center;
+          padding: 1rem;
+        }
+
+        .login-container {
+          justify-content: center;
+          max-width: min(100%, 32rem);
+          padding: 0;
+        }
+
+        .login-screen {
+          flex: 0 1 auto;
+          min-height: 0;
+          min-width: min(var(--min-width), 100%);
+          box-shadow: 0 0 0 1px var(--theme-border-subdued);
+        }
+
+        .login-status {
+          min-width: 0;
+          overflow: hidden;
+          color: var(--theme-muted);
+          opacity: 0.85;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .login-content {
+          display: grid;
+          gap: 1rem;
+          padding: 1rem;
+          line-height: 1.6;
+        }
+
+        .login-title {
+          margin: 0;
+          color: var(--theme-focused-foreground);
+          font-size: 1.25rem;
+          font-weight: 700;
+          letter-spacing: 0;
+        }
+
+        .login-form {
+          display: grid;
+          gap: 0.75rem;
+        }
+
+        .login-label {
+          color: var(--theme-muted);
+          font-weight: 700;
+        }
+
+        .login-input {
+          width: 100%;
+          min-height: var(--button-size);
+          border: 2px solid var(--theme-text);
+          border-radius: 0;
+          background: var(--theme-background-input);
+          color: var(--theme-focused-foreground);
+          font: inherit;
+          padding: 0.75rem;
+        }
+
+        .login-input:focus {
+          border-color: var(--theme-focused-foreground);
+          outline: none;
+        }
+
+        .login-submit {
+          width: 100%;
+          height: var(--button-size);
+        }
+
+        .login-error {
+          margin: 0;
+          padding: 0.75rem;
+          border: 1px solid var(--theme-focused-foreground);
+          color: var(--theme-focused-foreground);
+        }
+
+        @media (max-width: 22rem) {
+          .login-main {
+            padding: 0.75rem;
+          }
+
+          .login-content {
+            padding: 0.75rem;
+          }
+        }
+      </style>
+    </head>
+    <body>
+      <main class="gamepad-main login-main">
+        <div class="gamepad-container login-container">
+          <section class="terminal-screen login-screen" aria-labelledby="title">
+            <div class="mode-bar">
+              <strong class="mode-bar-title">Textile</strong>
+              <span class="login-status">private alpha</span>
+            </div>
+            <div class="login-content">
+              <h1 class="login-title" id="title">Enter password</h1>
+              ${message}
+              <form class="login-form" method="post" action="/_textile/login">
+                <input type="hidden" name="next" value="${safeNext}" />
+                <label class="login-label" for="password">Password</label>
+                <input class="login-input" id="password" name="password" type="password" autocomplete="current-password" autofocus />
+                <button class="gamepad-btn login-submit" type="submit">Enter</button>
+              </form>
+            </div>
+          </section>
+        </div>
+      </main>
+    </body>
+  </html>`;
 }
 
 export function setupSiteAuthRoutes(app: Application) {
+  app.get(LOGIN_STYLES_PATH, (_req, res) => {
+    res
+      .status(200)
+      .type("text/css")
+      .setHeader("Cache-Control", "no-cache")
+      .send(loadLoginStylesheet());
+  });
+
+  app.get(`${LOGIN_FONT_PATH}/:file`, (req, res) => {
+    const file = typeof req.params.file === "string" ? req.params.file : "";
+    if (!LOGIN_FONT_FILES.has(file)) {
+      res.status(404).send("Not found");
+      return;
+    }
+
+    const sourceFontPath = path.resolve(
+      process.cwd(),
+      "client/assets/fonts",
+      file,
+    );
+    const builtFontPath = path.resolve(
+      process.cwd(),
+      "dist/client/assets",
+      file,
+    );
+    const fontPath = fs.existsSync(sourceFontPath)
+      ? sourceFontPath
+      : builtFontPath;
+    if (!fs.existsSync(fontPath)) {
+      res.status(404).send("Not found");
+      return;
+    }
+
+    res
+      .status(200)
+      .type("font/woff2")
+      .setHeader("Cache-Control", "public, max-age=31536000, immutable")
+      .sendFile(fontPath);
+  });
+
   app.get("/_textile/login", (req, res) => {
     if (!isSiteAuthConfigured() || hasValidSiteSession(req)) {
       res.redirect(safeRedirectTarget(req.query.next));

--- a/server/siteAuth.ts
+++ b/server/siteAuth.ts
@@ -188,6 +188,19 @@ const themeBootstrapScript = `(() => {
   }
 })();`;
 
+const loginLayoutScript = `(() => {
+  const container = document.getElementById("login-container");
+  if (!container) return;
+  const update = () => {
+    const aspectRatio = container.clientWidth / container.clientHeight;
+    const landscape = aspectRatio >= 1.33;
+    container.classList.toggle("landscape", landscape);
+    container.classList.toggle("portrait", !landscape);
+  };
+  new ResizeObserver(update).observe(container);
+  update();
+})();`;
+
 function loginPage(next = "/", error = false) {
   const message = error
     ? "<p class=\"login-error\" role=\"alert\">That password did not work.</p>"
@@ -203,117 +216,110 @@ function loginPage(next = "/", error = false) {
       <script>${themeBootstrapScript}</script>
       <link rel="stylesheet" href="${LOGIN_STYLES_PATH}" />
       <style>
-        .login-main {
-          justify-content: center;
-          padding: 1rem;
-        }
-
-        .login-container {
-          justify-content: center;
-          max-width: min(100%, 32rem);
-          padding: 0;
-        }
-
-        .login-screen {
-          flex: 0 1 auto;
-          min-height: 0;
-          min-width: min(var(--min-width), 100%);
-          box-shadow: 0 0 0 1px var(--theme-border-subdued);
-        }
-
-        .login-status {
-          min-width: 0;
-          overflow: hidden;
-          color: var(--theme-muted);
-          opacity: 0.85;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
-
-        .login-content {
-          display: grid;
-          gap: 1rem;
-          padding: 1rem;
-          line-height: 1.6;
-        }
-
-        .login-title {
-          margin: 0;
-          color: var(--theme-focused-foreground);
-          font-size: 1.25rem;
-          font-weight: 700;
-          letter-spacing: 0;
-        }
-
         .login-form {
-          display: grid;
-          gap: 0.75rem;
+          display: contents;
         }
 
-        .login-label {
-          color: var(--theme-muted);
-          font-weight: 700;
+        .login-menu {
+          display: flex;
+          flex-direction: column;
+          gap: 0;
+          padding-top: 0.5rem;
         }
 
         .login-input {
           width: 100%;
-          min-height: var(--button-size);
-          border: 2px solid var(--theme-text);
+          min-width: 0;
+          border: 0;
           border-radius: 0;
-          background: var(--theme-background-input);
-          color: var(--theme-focused-foreground);
+          background: transparent;
+          color: inherit;
           font: inherit;
-          padding: 0.75rem;
+          line-height: 1.3;
+          outline: none;
+          padding: 0;
         }
 
-        .login-input:focus {
-          border-color: var(--theme-focused-foreground);
-          outline: none;
+        .login-input::placeholder {
+          color: currentColor;
+          opacity: 0.55;
+        }
+
+        .login-action {
+          appearance: none;
+          text-align: left;
         }
 
         .login-submit {
-          width: 100%;
-          height: var(--button-size);
+          border: 0;
+          font: inherit;
         }
 
         .login-error {
-          margin: 0;
-          padding: 0.75rem;
-          border: 1px solid var(--theme-focused-foreground);
-          color: var(--theme-focused-foreground);
+          margin: 0 1rem 0.5rem;
+          padding: 0.25rem 0.75rem;
+          background: var(--theme-background-input);
+          color: inherit;
         }
 
-        @media (max-width: 22rem) {
-          .login-main {
-            padding: 0.75rem;
-          }
-
-          .login-content {
-            padding: 0.75rem;
-          }
+        .login-controls {
+          pointer-events: none;
         }
       </style>
     </head>
     <body>
-      <main class="gamepad-main login-main">
-        <div class="gamepad-container login-container">
-          <section class="terminal-screen login-screen" aria-labelledby="title">
+      <main class="gamepad-main bg-theme-bg text-theme-text font-mono" aria-label="Textile Login">
+        <div id="login-container" class="gamepad-container portrait">
+          <section class="terminal-screen" aria-labelledby="title">
             <div class="mode-bar">
-              <strong class="mode-bar-title">Textile</strong>
-              <span class="login-status">private alpha</span>
+              <strong class="mode-bar-title" id="title">LOGIN</strong>
+              <div class="mode-bar-hint-frame">
+                <span class="mode-bar-hint" aria-label="status">PRIVATE ALPHA</span>
+              </div>
             </div>
-            <div class="login-content">
-              <h1 class="login-title" id="title">Enter password</h1>
-              ${message}
-              <form class="login-form" method="post" action="/_textile/login">
-                <input type="hidden" name="next" value="${safeNext}" />
-                <label class="login-label" for="password">Password</label>
-                <input class="login-input" id="password" name="password" type="password" autocomplete="current-password" autofocus />
-                <button class="gamepad-btn login-submit" type="submit">Enter</button>
-              </form>
+            <form class="login-form" method="post" action="/_textile/login">
+              <input type="hidden" name="next" value="${safeNext}" />
+              <div class="drawer">
+                <div class="drawer-body">
+                  <div class="menu-content login-menu">
+                    ${message}
+                    <label class="menu-item menu-item--row menu-item--pick selected" for="password">
+                      <span class="menu-item-label">Password:</span>
+                      <input class="login-input" id="password" name="password" type="password" autocomplete="current-password" placeholder="required" autofocus />
+                    </label>
+                    <button class="menu-item menu-item--row menu-item--action login-action" type="submit">
+                      <span class="menu-item-glyph" aria-hidden="true">↵</span>
+                      <span class="menu-item-label">Enter</span>
+                      <span class="menu-item-preview">continue to Textile</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+            <div class="navigation-bar">
+              <span class="navbar-minibuffer" aria-live="polite">Textile private alpha</span>
             </div>
           </section>
+          <div class="gamepad-controls login-controls" aria-hidden="true">
+            <div class="controls-top">
+              <div class="terminal-grid">
+                <div class="terminal-grid-cell"><button class="gamepad-btn" type="button" tabindex="-1">▲</button></div>
+                <div class="terminal-grid-cell"><button class="gamepad-btn" type="button" tabindex="-1">◀</button></div>
+                <div class="terminal-grid-cell"><button class="gamepad-btn" type="button" tabindex="-1">▶</button></div>
+                <div class="terminal-grid-cell"><button class="gamepad-btn" type="button" tabindex="-1">▼</button></div>
+              </div>
+              <div class="terminal-buttons">
+                <button class="gamepad-btn" type="button" tabindex="-1">⌫</button>
+                <button class="gamepad-btn" type="button" tabindex="-1">↵</button>
+              </div>
+            </div>
+            <div class="terminal-menu">
+              <button class="gamepad-btn" type="button" tabindex="-1">SELECT</button>
+              <button class="gamepad-btn" type="button" tabindex="-1">START</button>
+            </div>
+          </div>
         </div>
+        <script>${loginLayoutScript}</script>
       </main>
     </body>
   </html>`;


### PR DESCRIPTION
## Summary

- Serve the Textile app stylesheet to the unauthenticated login gate through a narrow `/_textile/terminal.css` route.
- Serve the app font files through `/_textile/fonts/*` so the login page can use the same theme/font classes before a site session exists.
- Render the login gate inside the same terminal/gamepad frame as the app: `gamepad-main`, `gamepad-container`, `terminal-screen`, `mode-bar`, menu rows, navigation bar, and inert gamepad controls.
- Preserve the same theme preference bootstrap used by the app so system theme and saved palette/font choices apply before paint.
- Match the app’s portrait/landscape breakpoint on the login shell.

## Validation

- `bun test ./server/__tests__/siteAuth.test.ts`
- `bun run lint`
- `bun run build`
- `bun test ./server ./client`
- `bun run test:e2e`
- Production-mode Playwright smoke with a fresh browser context, verifying `/` redirects to `/_textile/login`, no site cookie is present, the login form renders, and the story interface does not render.
- Production-mode Playwright visual/computed-style comparison against the app shell for dark mobile and saved Aperture desktop themes.