### PR TITLE
[codex] Report stalled Lync handshakes

### DIFF
--- a/vendor/lync/packages/client/src/sync.ts
+++ b/vendor/lync/packages/client/src/sync.ts
@@ -287,6 +287,7 @@ class ResilientWebSocketClientAdapter extends NetworkAdapter {
     }
 
     if (socket.readyState === WebSocket.CONNECTING) {
+      this.reportError(new Error("WebSocket handshake timed out"), true);
       this.abandonedHandshakeRetryAt = Date.now() + Math.max(this.retryInterval, 5_000);
       this.destroySocketTransport(socket);
       socket.terminate();

--- a/vendor/lync/packages/client/src/sync.ts
+++ b/vendor/lync/packages/client/src/sync.ts
@@ -110,7 +110,7 @@ class ResilientWebSocketClientAdapter extends NetworkAdapter {
       return;
     } else {
       const previousSocket = this.socket;
-      this.closeSocket(previousSocket);
+      this.closeSocket(previousSocket, { reportConnectingFailure: true });
       if (previousSocket.readyState !== WebSocket.CLOSED) {
         return;
       }
@@ -279,7 +279,10 @@ class ResilientWebSocketClientAdapter extends NetworkAdapter {
     socket.removeEventListener("error", this.onSocketError);
   }
 
-  private closeSocket(socket: WebSocket) {
+  private closeSocket(
+    socket: WebSocket,
+    options: { reportConnectingFailure?: boolean } = {},
+  ) {
     this.removeSocketListeners(socket);
     socket.addEventListener("error", swallowSocketAbortError);
     if (socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING) {
@@ -287,7 +290,9 @@ class ResilientWebSocketClientAdapter extends NetworkAdapter {
     }
 
     if (socket.readyState === WebSocket.CONNECTING) {
-      this.reportError(new Error("WebSocket handshake timed out"), true);
+      if (options.reportConnectingFailure) {
+        this.reportError(new Error("WebSocket handshake timed out"), true);
+      }
       this.abandonedHandshakeRetryAt = Date.now() + Math.max(this.retryInterval, 5_000);
       this.destroySocketTransport(socket);
       socket.terminate();

--- a/vendor/lync/packages/client/test/node.test.ts
+++ b/vendor/lync/packages/client/test/node.test.ts
@@ -85,6 +85,7 @@ describe("node loom client", () => {
 
   it("closes a hanging websocket before retrying", async () => {
     const upgradeSockets = new Set<net.Socket>();
+    const statuses: SyncStatus[] = [];
     const server = http.createServer();
     server.on("upgrade", (_request, socket) => {
       upgradeSockets.add(socket);
@@ -97,12 +98,21 @@ describe("node loom client", () => {
     const adapter = createWebSocketSyncAdapter({
       url: `ws://127.0.0.1:${address.port}/lync`,
       retryInterval: 20,
+      onStatus: (status) => statuses.push(status),
     });
 
     adapter.connect("peer-a" as PeerId);
     await new Promise((resolve) => setTimeout(resolve, 120));
 
     expect(upgradeSockets.size).toBeLessThanOrEqual(1);
+    expect(
+      statuses.some(
+        (status) =>
+          status.state === "failed" &&
+          status.recoverable &&
+          status.error.message === "WebSocket handshake timed out",
+      ),
+    ).toBe(true);
 
     adapter.disconnect();
     for (const socket of upgradeSockets) socket.destroy();

--- a/vendor/lync/packages/client/test/node.test.ts
+++ b/vendor/lync/packages/client/test/node.test.ts
@@ -118,4 +118,32 @@ describe("node loom client", () => {
     for (const socket of upgradeSockets) socket.destroy();
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
+
+  it("does not report a timeout when disconnecting during a handshake", async () => {
+    const upgradeSockets = new Set<net.Socket>();
+    const statuses: SyncStatus[] = [];
+    const server = http.createServer();
+    server.on("upgrade", (_request, socket) => {
+      upgradeSockets.add(socket);
+      socket.on("close", () => upgradeSockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP server");
+
+    const adapter = createWebSocketSyncAdapter({
+      url: `ws://127.0.0.1:${address.port}/lync`,
+      retryInterval: 20,
+      onStatus: (status) => statuses.push(status),
+    });
+
+    adapter.connect("peer-a" as PeerId);
+    adapter.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(statuses.some((status) => status.state === "failed")).toBe(false);
+
+    for (const socket of upgradeSockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #54 from production/local smoke testing.

- Reports a recoverable `WebSocket handshake timed out` status when the resilient Node sync adapter abandons a stuck `CONNECTING` socket.
- Extends the hanging-upgrade regression test to assert that callers receive that status instead of silent local-only continuation.

## Why

A deployed bad-token/no-token probe against `wss://textile.quest/lync` can hang at the proxy/upgrade layer rather than returning a prompt status. Local loom operations still continue, but without this callback Story Machine is too quiet about the sync failure.

## Validation

- `bun test vendor/lync/packages/client/test/node.test.ts vendor/lync/packages/sync-server/test/sync-server.test.ts`
- `bun run lint`
- `bun test ./server ./client`
- `bun run build`
- `pnpm test && pnpm typecheck` in Story Machine vendored Lync
- Bad deployed token smoke logs: `Textile live sync unavailable; continuing locally: WebSocket handshake timed out`