### PR TITLE
[codex] Tolerate Lync relay shutdown flush failures

### DIFF
--- a/server/lync.ts
+++ b/server/lync.ts
@@ -29,6 +29,17 @@ export function attachLyncServer(server: http.Server) {
   };
   relay = attachVendoredLyncServer(server, options);
 
+  server.on("upgrade", (request) => {
+    try {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      if (url.pathname === "/lync") {
+        console.log("[Lync] websocket upgrade requested");
+      }
+    } catch {
+      // Ignore malformed upgrade URLs; the relay handles rejection.
+    }
+  });
+
   relay.server.on("connection", (socket) => {
     const openConnections = relay?.server.clients.size ?? 0;
     console.log(`[Lync] websocket connected; open=${openConnections}`);

--- a/vendor/lync/packages/sync-server/src/index.ts
+++ b/vendor/lync/packages/sync-server/src/index.ts
@@ -94,11 +94,14 @@ export function attachLyncServer(
     head: Buffer,
   ) => {
     if (!isSocketPath(request, socketPath)) return;
+    console.log("[Lync] upgrade received by relay");
     if (closing) {
+      console.log("[Lync] rejecting upgrade: server closing");
       rejectUpgrade(socket, "503 Service Unavailable");
       return;
     }
     if (!isAuthorized(options.authenticate, request)) {
+      console.log("[Lync] rejecting upgrade: unauthorized");
       rejectUpgrade(socket, "401 Unauthorized");
       return;
     }
@@ -106,12 +109,14 @@ export function attachLyncServer(
       options.maxConnections !== undefined &&
       socketServer.clients.size >= options.maxConnections
     ) {
+      console.log("[Lync] rejecting upgrade: max connections");
       rejectUpgrade(socket, "503 Service Unavailable");
       return;
     }
     upgradeSockets.add(socket);
     socket.once("close", () => upgradeSockets.delete(socket));
     socketServer.handleUpgrade(request, socket, head, (websocket) => {
+      console.log("[Lync] upgrade accepted by relay");
       socketServer.emit("connection", websocket, request);
     });
   };

--- a/vendor/lync/packages/sync-server/src/index.ts
+++ b/vendor/lync/packages/sync-server/src/index.ts
@@ -175,7 +175,7 @@ async function closeRelay(
     for (const socket of upgradeSockets) socket.destroy();
   }, 1_500).unref?.();
 
-  await repo.shutdown();
+  await shutdownRepo(repo);
   await withTimeout(
     new Promise<void>((resolve, reject) => {
       socketServer.close((error?: Error) => {
@@ -185,6 +185,14 @@ async function closeRelay(
     }),
     2_000,
   );
+}
+
+async function shutdownRepo(repo: Repo) {
+  try {
+    await repo.shutdown();
+  } catch (error) {
+    console.warn("[Lync] repo shutdown failed; continuing shutdown", error);
+  }
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | void> {

--- a/vendor/lync/packages/sync-server/test/sync-server.test.ts
+++ b/vendor/lync/packages/sync-server/test/sync-server.test.ts
@@ -41,6 +41,21 @@ describe("lync server", () => {
     httpServer.close();
   });
 
+  it("does not fail shutdown when the repo cannot flush", async () => {
+    const httpServer = http.createServer();
+    const relay = attachLyncServer(httpServer, {
+      repo: {
+        peerId: "broken-shutdown-repo",
+        shutdown: async () => {
+          throw new Error("DocHandle is not ready");
+        },
+      } as never,
+    });
+
+    await expect(relay.close()).resolves.toBeUndefined();
+    httpServer.close();
+  });
+
   it("can authenticate websocket upgrades", async () => {
     const httpServer = http.createServer();
     const seenAuthHeaders: Array<string | undefined> = [];
@@ -105,6 +120,7 @@ describe("lync server", () => {
 
 function sendUpgrade(port: number) {
   return new Promise<string>((resolve, reject) => {
+    let settled = false;
     const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
       socket.write(
         [
@@ -123,8 +139,18 @@ function sendUpgrade(port: number) {
     socket.setTimeout(1000, () => {
       socket.destroy(new Error("Timed out waiting for websocket rejection"));
     });
-    socket.on("close", () => resolve("closed"));
-    socket.on("error", reject);
+    socket.on("data", (chunk) => {
+      if (!chunk.toString().startsWith("HTTP/1.1")) return;
+      settled = true;
+      socket.destroy();
+      resolve("closed");
+    });
+    socket.on("close", () => {
+      if (!settled) resolve("closed");
+    });
+    socket.on("error", (error) => {
+      if (!settled) reject(error);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- Treat Automerge repo shutdown failures as non-fatal during Lync relay shutdown
- Add a regression test for the `DocHandle is not ready` shutdown failure seen in production logs
- Make the raw websocket rejection test helper resolve on HTTP rejection bytes instead of relying on close timing

## Verification
- `cd vendor/lync && pnpm --filter @lync/sync-server typecheck`
- `cd vendor/lync && pnpm exec vitest run packages/sync-server/test/sync-server.test.ts`
- `bun test ./server ./client`
- `bun run build`