### PR TITLE
[codex] Fix browser Lync shared links

### DIFF
--- a/client/interface/Interface.tsx
+++ b/client/interface/Interface.tsx
@@ -59,6 +59,7 @@ import {
   createStoryIndexShareUrl,
   createStoryShareUrl,
   createStoryThreadShareUrl,
+  getStoryReferenceFromLocation,
   getStoryIndex,
   replaceStoryFocusUrl,
 } from "./lync/storyRuntime";
@@ -251,6 +252,10 @@ export const GamepadInterface = () => {
 
   useEffect(() => {
     if (hasAppliedDefault.current) return;
+    if (getStoryReferenceFromLocation()) {
+      hasAppliedDefault.current = true;
+      return;
+    }
     const keys = Object.keys(trees);
     if (!keys.length) return;
     const preferred = getDefaultStoryKey(trees) ?? orderedKeys[0];

--- a/vendor/lync/packages/core/src/browser.ts
+++ b/vendor/lync/packages/core/src/browser.ts
@@ -1,3 +1,4 @@
+import "@automerge/automerge";
 import { Repo, type RepoConfig } from "@automerge/automerge-repo";
 import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-indexeddb";
 import { BroadcastChannelNetworkAdapter } from "@automerge/automerge-repo-network-broadcastchannel";


### PR DESCRIPTION
## Summary
- initialize Automerge's browser WASM entrypoint before Lync creates browser repos
- prevent the local most-recent-story default from overriding incoming shared ?ref links

## Why
The app shell could render and the websocket could connect, but browser Automerge document creation failed with `Automerge.use() not called`. Incoming shared refs could also be replaced by local story focus before the imported loom took over.

## Validation
- bun test client/interface/lync/__tests__/storyRuntime.test.ts client/interface/hooks/__tests__/useStoryTree.test.ts client/interface/lync/__tests__/storyLoom.test.ts
- PLAYWRIGHT_PORT=5174 PLAYWRIGHT_REUSE_SERVER=true npx playwright test tests/e2e/lync-story.spec.ts --grep "copied story link opens|copied thread link opens|browser URL follows"